### PR TITLE
Only run service actions in specific states

### DIFF
--- a/src/ScaleUnitManagement/ScaleUnitFeatureManager/Utilities/ServiceHelper.cs
+++ b/src/ScaleUnitManagement/ScaleUnitFeatureManager/Utilities/ServiceHelper.cs
@@ -10,6 +10,12 @@ namespace ScaleUnitManagement.ScaleUnitFeatureManager.Utilities
             RunServiceAction(serviceName, svc => {
                 Console.WriteLine($"Starting service {serviceName}..");
 
+                if (svc.Status == ServiceControllerStatus.Running)
+                {
+                    Console.WriteLine($"{serviceName} already started");
+                    return;
+                }
+
                 svc.Start();
                 svc.WaitForStatus(ServiceControllerStatus.Running, timeout);
 
@@ -19,6 +25,12 @@ namespace ScaleUnitManagement.ScaleUnitFeatureManager.Utilities
         public static void StopService(string serviceName, TimeSpan timeout) =>
             RunServiceAction(serviceName, svc => {
                 Console.WriteLine($"Stopping service {serviceName}..");
+
+                if (svc.Status != ServiceControllerStatus.Running)
+                {
+                    Console.WriteLine($"{serviceName} already stopping or stopped");
+                    return;
+                }
 
                 svc.Stop();
                 svc.WaitForStatus(ServiceControllerStatus.Stopped, timeout);


### PR DESCRIPTION
`ServiceController` throws an exception if you attempt to start/stop a service when it is already in the desired state. We want our API to be idempotent in this case instead.