### PR TITLE
Set temporal assignments' effective date in the future =< 10.0.21

### DIFF
--- a/src/ScaleUnitManagement/Utilities/AxDeployment.cs
+++ b/src/ScaleUnitManagement/Utilities/AxDeployment.cs
@@ -39,9 +39,11 @@ namespace ScaleUnitManagement.Utilities
             string[] deployedApplicationVersion = GetApplicationVersion().Split('.');
             string[] compareToVersion = version.Split('.');
 
-            for (int i = 0; i < deployedApplicationVersion.Length && i < compareToVersion.Length; i++)
+            for (int i = 0; i < deployedApplicationVersion.Length; i++)
             {
-                if (Int32.Parse(deployedApplicationVersion[i]) < Int32.Parse(compareToVersion[i]))
+                if (i >= compareToVersion.Length)
+                    return true;
+                else if (Int32.Parse(deployedApplicationVersion[i]) < Int32.Parse(compareToVersion[i]))
                     return false;
                 else if (Int32.Parse(deployedApplicationVersion[i]) > Int32.Parse(compareToVersion[i]))
                     return true;

--- a/src/ScaleUnitManagement/WorkloadSetupOrchestrator/Utilities/WorkloadInstanceManager.cs
+++ b/src/ScaleUnitManagement/WorkloadSetupOrchestrator/Utilities/WorkloadInstanceManager.cs
@@ -66,7 +66,7 @@ namespace ScaleUnitManagement.WorkloadSetupOrchestrator.Utilities
                             {
                                 new TemporalAssignment()
                                 {
-                                    EffectiveDate = DateTime.UtcNow,
+                                    EffectiveDate = GetWorkloadEffectiveDate(),
                                     Environment = new PhysicalEnvironmentReference()
                                     {
                                         Id = Config.ScaleUnitEnvironmentId,
@@ -248,7 +248,7 @@ namespace ScaleUnitManagement.WorkloadSetupOrchestrator.Utilities
                     {
                         new TemporalAssignment()
                         {
-                            EffectiveDate = DateTime.UtcNow,
+                            EffectiveDate = GetWorkloadEffectiveDate(),
                             Environment = new PhysicalEnvironmentReference()
                             {
                                 Id = Config.ScaleUnitEnvironmentId,
@@ -274,6 +274,16 @@ namespace ScaleUnitManagement.WorkloadSetupOrchestrator.Utilities
             }
 
             return sysWorkloadInstances;
+        }
+
+        private static DateTime GetWorkloadEffectiveDate()
+        {
+            DateTime effectiveDate = DateTime.UtcNow;
+            if (!AxDeployment.IsApplicationVersionMoreRecentThan("10.0.21"))
+            {
+                effectiveDate.AddMinutes(5);
+            }
+            return effectiveDate;
         }
 
         public static async Task<WorkloadInstanceStatus> GetWorkloadInstanceStatus(AOSClient client, string workloadInstanceId)

--- a/src/ScaleUnitManagement/WorkloadSetupOrchestrator/Utilities/WorkloadInstanceManager.cs
+++ b/src/ScaleUnitManagement/WorkloadSetupOrchestrator/Utilities/WorkloadInstanceManager.cs
@@ -279,7 +279,8 @@ namespace ScaleUnitManagement.WorkloadSetupOrchestrator.Utilities
         private static DateTime GetWorkloadEffectiveDate()
         {
             DateTime effectiveDate = DateTime.UtcNow;
-            if (!AxDeployment.IsApplicationVersionMoreRecentThan("10.13"))
+            string app10_0_22BaseVersion = "10.13";
+            if (!AxDeployment.IsApplicationVersionMoreRecentThan(app10_0_22BaseVersion))
             {
                 effectiveDate.AddMinutes(5);
             }

--- a/src/ScaleUnitManagement/WorkloadSetupOrchestrator/Utilities/WorkloadInstanceManager.cs
+++ b/src/ScaleUnitManagement/WorkloadSetupOrchestrator/Utilities/WorkloadInstanceManager.cs
@@ -279,7 +279,7 @@ namespace ScaleUnitManagement.WorkloadSetupOrchestrator.Utilities
         private static DateTime GetWorkloadEffectiveDate()
         {
             DateTime effectiveDate = DateTime.UtcNow;
-            if (!AxDeployment.IsApplicationVersionMoreRecentThan("10.0.21"))
+            if (!AxDeployment.IsApplicationVersionMoreRecentThan("10.13"))
             {
                 effectiveDate.AddMinutes(5);
             }

--- a/src/ScaleUnitManagementTests/AxDeploymentTest.cs
+++ b/src/ScaleUnitManagementTests/AxDeploymentTest.cs
@@ -51,5 +51,17 @@ namespace ScaleUnitManagementTests
             // Act + Assert
             AxDeployment.IsApplicationVersionMoreRecentThan("10.8.107.1233").Should().BeFalse();
         }
+
+        [TestMethod]
+        public void IsApplicationVersionMoreRecentThan_SpecificVersion()
+        {
+            // Arrange
+            AxDeploymentTestable.SetApplicationVersion("10.13.1837");
+
+            // Act + Assert
+            AxDeployment.IsApplicationVersionMoreRecentThan("10.13.0").Should().BeTrue();
+            AxDeployment.IsApplicationVersionMoreRecentThan("10.13").Should().BeTrue();
+        }
+
     }
 }


### PR DESCRIPTION
Changing the effective date on the workloads when they are installed.
If the version is 10.0.21 or earlier, 5 minutes are added to the time, such that the installation succeeds first and the movement jobs will get created.