### PR TITLE
Checking if the scaleUnitId is valid

### DIFF
--- a/src/ScaleUnitManagement/Utilities/Config.cs
+++ b/src/ScaleUnitManagement/Utilities/Config.cs
@@ -153,6 +153,7 @@ namespace ScaleUnitManagement.Utilities
                 if (!scaleUnit.IsHub() && (integralScaleUnitId < 1 || 1000 <= integralScaleUnitId))
                     Console.Error.WriteLine("ScaleUnitId is not in the mnemonic range (between 0 and 1000)");
 
+
                 if (Config.ScaleUnitInstances().Where(s => s.ScaleUnitId == scaleUnit.ScaleUnitId).Count() != 1)
                     Console.Error.WriteLine("ScaleUnitId is not unique");
 

--- a/src/ScaleUnitManagement/Utilities/Config.cs
+++ b/src/ScaleUnitManagement/Utilities/Config.cs
@@ -149,6 +149,10 @@ namespace ScaleUnitManagement.Utilities
                 ValidateValue("AppSecret", scaleUnit.AuthConfiguration.AppSecret);
                 ValidateValue("Authority", scaleUnit.AuthConfiguration.Authority);
 
+                int integralScaleUnitId = ScaleUnitMnemonicCalculator.ToIntegralValue(scaleUnit.ScaleUnitId);
+                if (!scaleUnit.IsHub() && (integralScaleUnitId < 1 || 1000 <= integralScaleUnitId))
+                    Console.Error.WriteLine("ScaleUnitId is not in the mnemonic range (between 0 and 1000)");
+
                 if (Config.ScaleUnitInstances().Where(s => s.ScaleUnitId == scaleUnit.ScaleUnitId).Count() != 1)
                     Console.Error.WriteLine("ScaleUnitId is not unique");
 

--- a/src/ScaleUnitManagement/Utilities/Config.cs
+++ b/src/ScaleUnitManagement/Utilities/Config.cs
@@ -156,7 +156,7 @@ namespace ScaleUnitManagement.Utilities
                         int integralScaleUnitId = ScaleUnitMnemonicCalculator.ToIntegralValue(scaleUnit.ScaleUnitId);
                         if (integralScaleUnitId < 1 || integralScaleUnitId >= 1000)
                         {
-                            Console.Error.WriteLine("ScaleUnitId is not in the mnemonic range (between 1 and 1000)");
+                            Console.Error.WriteLine("ScaleUnitId \"" + (scaleUnit.ScaleUnitId) + "\" (" + integralScaleUnitId + ") is not in the mnemonic range (between 1 and 1000)");
                             hasAnyError = true;
                         }
                     } catch (Exception e)

--- a/src/ScaleUnitManagement/Utilities/Config.cs
+++ b/src/ScaleUnitManagement/Utilities/Config.cs
@@ -149,9 +149,22 @@ namespace ScaleUnitManagement.Utilities
                 ValidateValue("AppSecret", scaleUnit.AuthConfiguration.AppSecret);
                 ValidateValue("Authority", scaleUnit.AuthConfiguration.Authority);
 
-                int integralScaleUnitId = ScaleUnitMnemonicCalculator.ToIntegralValue(scaleUnit.ScaleUnitId);
-                if (!scaleUnit.IsHub() && (integralScaleUnitId < 1 || 1000 <= integralScaleUnitId))
-                    Console.Error.WriteLine("ScaleUnitId is not in the mnemonic range (between 0 and 1000)");
+                if (!scaleUnit.IsHub())
+                {
+                    try
+                    {
+                        int integralScaleUnitId = ScaleUnitMnemonicCalculator.ToIntegralValue(scaleUnit.ScaleUnitId);
+                        if (integralScaleUnitId < 1 || integralScaleUnitId >= 1000)
+                        {
+                            Console.Error.WriteLine("ScaleUnitId is not in the mnemonic range (between 0 and 1000)");
+                            hasAnyError = true;
+                        }
+                    } catch (Exception e)
+                    {
+                        hasAnyError = true;
+                        Console.Error.WriteLine(e.Message);
+                    }
+                }
 
 
                 if (Config.ScaleUnitInstances().Where(s => s.ScaleUnitId == scaleUnit.ScaleUnitId).Count() != 1)

--- a/src/ScaleUnitManagement/Utilities/Config.cs
+++ b/src/ScaleUnitManagement/Utilities/Config.cs
@@ -156,7 +156,7 @@ namespace ScaleUnitManagement.Utilities
                         int integralScaleUnitId = ScaleUnitMnemonicCalculator.ToIntegralValue(scaleUnit.ScaleUnitId);
                         if (integralScaleUnitId < 1 || integralScaleUnitId >= 1000)
                         {
-                            Console.Error.WriteLine("ScaleUnitId is not in the mnemonic range (between 0 and 1000)");
+                            Console.Error.WriteLine("ScaleUnitId is not in the mnemonic range (between 1 and 1000)");
                             hasAnyError = true;
                         }
                     } catch (Exception e)

--- a/src/ScaleUnitManagement/Utilities/ScaleUnitMnemonicCalculator.cs
+++ b/src/ScaleUnitManagement/Utilities/ScaleUnitMnemonicCalculator.cs
@@ -22,16 +22,16 @@ namespace ScaleUnitManagement.Utilities
                 return "@@";
             }
 
-            StringBuilder mnemonicString = new StringBuilder();
+            string mnemonicString = "";
             const char baseChar = '@';
             const int numberBase = 27;
             while (integralValue > 0)
             {
                 int remainder = integralValue % numberBase;
                 integralValue /= numberBase;
-                mnemonicString.Append((char)(baseChar + remainder));
+                mnemonicString += (char)(baseChar + remainder);
             }
-            var result = new String(mnemonicString.ToString().Reverse().ToArray());
+            var result = new String(mnemonicString.Reverse().ToArray());
             if (result.Count() == 1)
             {
                 // Prefix with additive identity.
@@ -47,18 +47,16 @@ namespace ScaleUnitManagement.Utilities
             // Use '@' as base so that 'A' isn't logically zero, making 'AAA' is different from 'AA', e.g.
             const char baseChar = '@';
             int integralValue = 0;
-            int i = 0;
-            foreach (var charIt in mnemonic)
+            for (int i = 0; i < mnemonic.Length; i++)
             {
-                int value = charIt - baseChar;
+                int value = mnemonic[i] - baseChar;
                 if (value < 0 || value >= 27)
                 {
-                    throw new Exception($"Scale set mnemonic has the invalid character '{charIt}'. Valid character values are '@' and the alpha characters A through Z.");
+                    throw new Exception($"Scale set mnemonic has the invalid character '{mnemonic[i]}'. Valid character values are '@' and the alpha characters A through Z.");
                 }
 
                 var position = mnemonic.Length - 1 - i;
                 integralValue += value * (int)Math.Pow(27, position);
-                i++;
             }
 
             return integralValue;

--- a/src/ScaleUnitManagement/Utilities/ScaleUnitMnemonicCalculator.cs
+++ b/src/ScaleUnitManagement/Utilities/ScaleUnitMnemonicCalculator.cs
@@ -1,0 +1,67 @@
+// ------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Linq;
+using System.Text;
+
+namespace ScaleUnitManagement.Utilities
+{
+    public static class ScaleUnitMnemonicCalculator
+    {
+        public static string ToMnemonic(int integralValue)
+        {
+            if (integralValue < 0)
+            {
+                throw new Exception($"Unable to convert integral value of {integralValue} to a scale unit mnemonic as it is negative.");
+            }
+
+            if (integralValue == 0)
+            {
+                return "@@";
+            }
+
+            StringBuilder mnemonicString = new StringBuilder();
+            const char baseChar = '@';
+            const int numberBase = 27;
+            while (integralValue > 0)
+            {
+                int remainder = integralValue % numberBase;
+                integralValue /= numberBase;
+                mnemonicString.Append((char)(baseChar + remainder));
+            }
+            var result = new String(mnemonicString.ToString().Reverse().ToArray());
+            if (result.Count() == 1)
+            {
+                // Prefix with additive identity.
+                result = baseChar + result;
+            }
+            return result;
+        }
+
+        public static int ToIntegralValue(string mnemonic)
+        {
+            mnemonic = mnemonic.ToUpperInvariant();
+
+            // Use '@' as base so that 'A' isn't logically zero, making 'AAA' is different from 'AA', e.g.
+            const char baseChar = '@';
+            int integralValue = 0;
+            int i = 0;
+            foreach (var charIt in mnemonic)
+            {
+                int value = charIt - baseChar;
+                if (value < 0 || value >= 27)
+                {
+                    throw new Exception($"Scale set mnemonic has the invalid character '{charIt}'. Valid character values are '@' and the alpha characters A through Z.");
+                }
+
+                var position = mnemonic.Length - 1 - i;
+                integralValue += value * (int)Math.Pow(27, position);
+                i++;
+            }
+
+            return integralValue;
+        }
+    }
+}

--- a/src/ScaleUnitManagementTests/ScaleUnitMnemonicCalculatorTest.cs
+++ b/src/ScaleUnitManagementTests/ScaleUnitMnemonicCalculatorTest.cs
@@ -1,0 +1,70 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using FluentAssertions;
+using ScaleUnitManagement.Utilities;
+using System;
+
+namespace ScaleUnitManagementTests
+{
+    [TestClass]
+    public class ScaleUnitMnemonicCalculatorTest
+    {
+        
+        [TestMethod]
+        public void ToIntegralValue_WithValidMnemonic_ReturnsIntegral()
+        {
+            // Arrange + Act + Assert
+            ScaleUnitMnemonicCalculator.ToIntegralValue("@@").Should().Be(0);
+            ScaleUnitMnemonicCalculator.ToIntegralValue("AB").Should().Be(29);
+            ScaleUnitMnemonicCalculator.ToIntegralValue("DAD").Should().Be(2947);
+            ScaleUnitMnemonicCalculator.ToIntegralValue("@@@H").Should().Be(8);
+        }
+
+        [TestMethod]
+        public void ToIntegralValue_WithInvalidMnemonic_ThrowsException()
+        {
+            // Arrange
+            bool exceptionThrown = false;
+
+            // Act
+            try
+            {
+                ScaleUnitMnemonicCalculator.ToIntegralValue("1");
+            }
+            catch (Exception)
+            {
+                exceptionThrown = true;
+            }
+
+            exceptionThrown.Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void ToMnemonic_WithValidIntegral_ReturnsMnemonic()
+        {
+            // Arrange + Act + Assert
+            ScaleUnitMnemonicCalculator.ToMnemonic(0).Should().Be("@@");
+            ScaleUnitMnemonicCalculator.ToMnemonic(29).Should().Be("AB");
+            ScaleUnitMnemonicCalculator.ToMnemonic(2947).Should().Be("DAD");
+            ScaleUnitMnemonicCalculator.ToMnemonic(8).Should().Be("@H");
+        }
+
+        [TestMethod]
+        public void ToMnemonic_WithInvalidInteger_ThrowsException()
+        {
+            // Arrange
+            bool exceptionThrown = false;
+
+            // Act
+            try
+            {
+                ScaleUnitMnemonicCalculator.ToMnemonic(-1);
+            }
+            catch (Exception)
+            {
+                exceptionThrown = true;
+            }
+
+            exceptionThrown.Should().BeTrue();
+        }
+    }
+}


### PR DESCRIPTION
// Not tested

Checking when the config is loaded if the ScaleUnitId is valid, i.e. if it lies within 1 and 1000 or is a hub.

resolves #63 