### PR TITLE
Creating Setup Tools menu, which allows syncing both the Hub and the Spoke

### DIFF
--- a/src/CLI/Program.cs
+++ b/src/CLI/Program.cs
@@ -15,7 +15,7 @@ namespace CLI
             var configureEnvironmentOption = new CLIOption() { Name = "Prepare environments for workload installation", Command = ConfigureEnvironment.Show };
             var installWorkloadsOption = new CLIOption() { Name = "Install workloads", Command = InstallWorkloads.Show };
             var workloadsInstallationStatusOption = new CLIOption() { Name = "Show workloads installation status", Command = WorkloadsInstallationStatus.Show };
-
+            var setupToolsOption = new CLIOption() { Name = "Setup tools", Command = SetupTools.Show };
             var options = new List<CLIOption>() { enableScaleUnitFeatureOption, configureEnvironmentOption, installWorkloadsOption, workloadsInstallationStatusOption };
 
             var screen = new CLIScreen(options, "Home", "Please select the operation you want to perform:\n", "\nOperation to perform: ");

--- a/src/CLI/Program.cs
+++ b/src/CLI/Program.cs
@@ -16,7 +16,7 @@ namespace CLI
             var installWorkloadsOption = new CLIOption() { Name = "Install workloads", Command = InstallWorkloads.Show };
             var workloadsInstallationStatusOption = new CLIOption() { Name = "Show workloads installation status", Command = WorkloadsInstallationStatus.Show };
             var setupToolsOption = new CLIOption() { Name = "Setup tools", Command = SetupTools.Show };
-            var options = new List<CLIOption>() { enableScaleUnitFeatureOption, configureEnvironmentOption, installWorkloadsOption, workloadsInstallationStatusOption };
+            var options = new List<CLIOption>() { enableScaleUnitFeatureOption, configureEnvironmentOption, installWorkloadsOption, workloadsInstallationStatusOption, setupToolsOption };
 
             var screen = new CLIScreen(options, "Home", "Please select the operation you want to perform:\n", "\nOperation to perform: ");
             await CLIMenu.ShowScreen(screen);

--- a/src/CLI/SetupTools.cs
+++ b/src/CLI/SetupTools.cs
@@ -12,7 +12,6 @@ namespace CLI
 
             options.Add(new CLIOption() { Name = "Sync DB", Command = SyncDB.Show });
 
-
             var screen = new CLIScreen(options, "Home", "Please select the operation you want to perform:\n", "\nOperation to perform: ");
             await CLIMenu.ShowScreen(screen);
         }

--- a/src/CLI/SetupTools.cs
+++ b/src/CLI/SetupTools.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using CLIFramework;
+
+namespace CLI
+{
+    class SetupTools
+    {
+        public static async Task Show(int input, string selectionHistory)
+        {
+            var options = new List<CLIOption>();
+
+            options.Add(new CLIOption() { Name = "Sync DB", Command = SyncDB.Show });
+
+
+            var screen = new CLIScreen(options, "Home", "Please select the operation you want to perform:\n", "\nOperation to perform: ");
+            await CLIMenu.ShowScreen(screen);
+        }
+    }
+}

--- a/src/CLI/SyncDB.cs
+++ b/src/CLI/SyncDB.cs
@@ -13,7 +13,6 @@ namespace CLI
         {
             var options = new List<CLIOption>();
 
-            options.Add(new CLIOption() { Name = "Hub", Command = SyncHubDB });
 
             if (Config.UseSingleOneBox())
             {
@@ -25,7 +24,10 @@ namespace CLI
                     options.Add(new CLIOption() { Name = scaleUnit.PrintableName(), Command = SyncSpokeDB });
                 }
             }
-
+            else
+            {
+                options.Add(new CLIOption() { Name = "Hub", Command = SyncHubDB });
+            }
 
             var screen = new CLIScreen(options, "Home", "Please select the database you would like to sync:\n", "\nDatabase to sync: ");
             await CLIMenu.ShowScreen(screen);

--- a/src/CLI/SyncDB.cs
+++ b/src/CLI/SyncDB.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using CLIFramework;
+using ScaleUnitManagement.Utilities;
+using ScaleUnitManagement.ScaleUnitFeatureManager.Hub;
+using ScaleUnitManagement.ScaleUnitFeatureManager.ScaleUnit;
+
+namespace CLI
+{
+    class SyncDB
+    {
+        public static async Task Show(int input, string selectionHistory)
+        {
+            var options = new List<CLIOption>();
+
+            options.Add(new CLIOption() { Name = "Hub", Command = SyncHubDB });
+
+            if (Config.UseSingleOneBox())
+            {
+                List<ScaleUnitInstance> scaleUnitInstances = Config.ScaleUnitInstances();
+                scaleUnitInstances.Sort();
+
+                foreach (ScaleUnitInstance scaleUnit in scaleUnitInstances)
+                {
+                    options.Add(new CLIOption() { Name = scaleUnit.PrintableName(), Command = SyncSpokeDB });
+                }
+            }
+
+
+            var screen = new CLIScreen(options, "Home", "Please select the database you would like to sync:\n", "\nDatabase to sync: ");
+            await CLIMenu.ShowScreen(screen);
+        }
+
+        private static async Task SyncHubDB(int input, string selectionHistory)
+        {
+            HubDBSync hubDBSync = new HubDBSync();
+            await hubDBSync.Run();
+        }
+        private static async Task SyncSpokeDB(int input, string selectionHistory)
+        {
+            List<ScaleUnitInstance> scaleUnitInstances = Config.ScaleUnitInstances();
+            scaleUnitInstances.Sort();
+            ScaleUnitDBSync scaleUnitDBSync = new ScaleUnitDBSync();
+            using (var context = ScaleUnitContext.CreateContext(scaleUnitInstances[input - 1].ScaleUnitId))
+            {
+                await scaleUnitDBSync.Run();
+            }
+        }
+    }
+}

--- a/src/CLI/SyncDB.cs
+++ b/src/CLI/SyncDB.cs
@@ -4,6 +4,7 @@ using CLIFramework;
 using ScaleUnitManagement.Utilities;
 using ScaleUnitManagement.ScaleUnitFeatureManager.Hub;
 using ScaleUnitManagement.ScaleUnitFeatureManager.ScaleUnit;
+using System;
 
 namespace CLI
 {
@@ -35,8 +36,15 @@ namespace CLI
 
         private static async Task SyncHubDB(int input, string selectionHistory)
         {
-            HubDBSync hubDBSync = new HubDBSync();
-            await hubDBSync.Run();
+            try
+            {
+                HubDBSync hubDBSync = new HubDBSync();
+                await hubDBSync.Run();
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"An error occured while trying to run DbSync:\n{ex}");
+            }
         }
         private static async Task SyncSpokeDB(int input, string selectionHistory)
         {
@@ -45,7 +53,14 @@ namespace CLI
             ScaleUnitDBSync scaleUnitDBSync = new ScaleUnitDBSync();
             using (var context = ScaleUnitContext.CreateContext(scaleUnitInstances[input - 1].ScaleUnitId))
             {
-                await scaleUnitDBSync.Run();
+                try
+                {
+                    await scaleUnitDBSync.Run();
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine($"An error occured while trying to run DbSync:\n{ex}");
+                }
             }
         }
     }

--- a/src/CLI/SyncDB.cs
+++ b/src/CLI/SyncDB.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using CLIFramework;
 using ScaleUnitManagement.Utilities;
-using ScaleUnitManagement.ScaleUnitFeatureManager.Hub;
 using ScaleUnitManagement.ScaleUnitFeatureManager.ScaleUnit;
 using System;
 
@@ -13,40 +12,19 @@ namespace CLI
         public static async Task Show(int input, string selectionHistory)
         {
             var options = new List<CLIOption>();
+            List<ScaleUnitInstance> scaleUnitInstances = Config.ScaleUnitInstances();
+            scaleUnitInstances.Sort();
 
-
-            if (Config.UseSingleOneBox())
+            foreach (ScaleUnitInstance scaleUnit in scaleUnitInstances)
             {
-                List<ScaleUnitInstance> scaleUnitInstances = Config.ScaleUnitInstances();
-                scaleUnitInstances.Sort();
-
-                foreach (ScaleUnitInstance scaleUnit in scaleUnitInstances)
-                {
-                    options.Add(new CLIOption() { Name = scaleUnit.PrintableName(), Command = SyncSpokeDB });
-                }
-            }
-            else
-            {
-                options.Add(new CLIOption() { Name = "Hub", Command = SyncHubDB });
+                options.Add(new CLIOption() { Name = scaleUnit.PrintableName(), Command = RunSyncDB });
             }
 
             var screen = new CLIScreen(options, "Home", "Please select the database you would like to sync:\n", "\nDatabase to sync: ");
             await CLIMenu.ShowScreen(screen);
         }
 
-        private static async Task SyncHubDB(int input, string selectionHistory)
-        {
-            try
-            {
-                HubDBSync hubDBSync = new HubDBSync();
-                await hubDBSync.Run();
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine($"An error occured while trying to run DbSync:\n{ex}");
-            }
-        }
-        private static async Task SyncSpokeDB(int input, string selectionHistory)
+        private static async Task RunSyncDB(int input, string selectionHistory)
         {
             List<ScaleUnitInstance> scaleUnitInstances = Config.ScaleUnitInstances();
             scaleUnitInstances.Sort();

--- a/src/ScaleUnitManagement/ScaleUnitFeatureManager/Common/RunDBSync.cs
+++ b/src/ScaleUnitManagement/ScaleUnitFeatureManager/Common/RunDBSync.cs
@@ -19,7 +19,7 @@ namespace ScaleUnitManagement.ScaleUnitFeatureManager.Common
 
         public void Run()
         {
-            Console.WriteLine("2. Executing DbSync");
+            Console.WriteLine("Executing DbSync");
 
             try
             {


### PR DESCRIPTION
Added a new option to the start menu: "Setup Tools". From here the user can sync the HubDB, or select a ScaleUnit to sync. The scale units only appear if UseSingleOneBox is true.