### PR TITLE
Replace use of Powershell scripts using SqlClient and Process.Start

### DIFF
--- a/src/ScaleUnitManagement/ScaleUnitFeatureManager/Common/AddToolClientToSysAADClientTable.cs
+++ b/src/ScaleUnitManagement/ScaleUnitFeatureManager/Common/AddToolClientToSysAADClientTable.cs
@@ -1,5 +1,5 @@
+using System.Data.SqlClient;
 using System.Threading.Tasks;
-using ScaleUnitManagement.ScaleUnitFeatureManager.Utilities;
 using ScaleUnitManagement.Utilities;
 
 namespace ScaleUnitManagement.ScaleUnitFeatureManager.Common
@@ -23,21 +23,28 @@ namespace ScaleUnitManagement.ScaleUnitFeatureManager.Common
             ScaleUnitInstance scaleUnit = Config.FindScaleUnitWithId(ScaleUnitContext.GetScaleUnitId());
 
             string sqlQuery = $@"
-USE {scaleUnit.AxDbName};
+            USE {scaleUnit.AxDbName};
 
-IF NOT EXISTS (SELECT TOP 1 1 FROM SysAADClientTable WHERE AADClientId = '{scaleUnit.AuthConfiguration.AppId}')
-BEGIN
-    IF EXISTS (SELECT TOP 1 1 FROM USERINFO WHERE ID = '{ScaleUnitManagementUserName}')
-        INSERT INTO SysAADClientTable (AADClientId, UserId, Name) VALUES ('{scaleUnit.AuthConfiguration.AppId}', '{ScaleUnitManagementUserName}', 'Scale Unit Management Tool');
-    ELSE
-        INSERT INTO SysAADClientTable (AADClientId, UserId, Name) VALUES ('{scaleUnit.AuthConfiguration.AppId}', 'Admin', 'Scale Unit Management Tool');
-END
-";
+            IF NOT EXISTS (SELECT TOP 1 1 FROM SysAADClientTable WHERE AADClientId = '{scaleUnit.AuthConfiguration.AppId}')
+            BEGIN
+                IF EXISTS (SELECT TOP 1 1 FROM USERINFO WHERE ID = '{ScaleUnitManagementUserName}')
+                    INSERT INTO SysAADClientTable (AADClientId, UserId, Name) VALUES ('{scaleUnit.AuthConfiguration.AppId}', '{ScaleUnitManagementUserName}', 'Scale Unit Management Tool');
+                ELSE
+                    INSERT INTO SysAADClientTable (AADClientId, UserId, Name) VALUES ('{scaleUnit.AuthConfiguration.AppId}', 'Admin', 'Scale Unit Management Tool');
+            END
+            ";
 
-            string cmd = "Invoke-SqlCmd -Query " + CommandExecutor.Quotes + sqlQuery + CommandExecutor.Quotes + " -QueryTimeout 65535";
 
-            CommandExecutor ce = new CommandExecutor();
-            ce.RunCommand(cmd);
+            string connectionString = $"Data Source=localhost;Initial Catalog={scaleUnit.AxDbName};Integrated Security=True;Enlist=True;Application Name=ScaleUnitDevTool";
+            using (SqlConnection conn = new SqlConnection(connectionString))
+            {
+                using (SqlCommand cmd = new SqlCommand(sqlQuery, conn))
+                {
+                    conn.Open();
+                    cmd.CommandTimeout = 65535;
+                    cmd.ExecuteNonQuery();
+                }
+            }
 
             return Task.CompletedTask;
         }

--- a/src/ScaleUnitManagement/ScaleUnitFeatureManager/Common/AddToolClientToSysAADClientTable.cs
+++ b/src/ScaleUnitManagement/ScaleUnitFeatureManager/Common/AddToolClientToSysAADClientTable.cs
@@ -1,5 +1,5 @@
-using System.Data.SqlClient;
 using System.Threading.Tasks;
+using ScaleUnitManagement.ScaleUnitFeatureManager.Utilities;
 using ScaleUnitManagement.Utilities;
 
 namespace ScaleUnitManagement.ScaleUnitFeatureManager.Common
@@ -34,17 +34,8 @@ namespace ScaleUnitManagement.ScaleUnitFeatureManager.Common
             END
             ";
 
-
-            string connectionString = $"Data Source=localhost;Initial Catalog={scaleUnit.AxDbName};Integrated Security=True;Enlist=True;Application Name=ScaleUnitDevTool";
-            using (SqlConnection conn = new SqlConnection(connectionString))
-            {
-                using (SqlCommand cmd = new SqlCommand(sqlQuery, conn))
-                {
-                    conn.Open();
-                    cmd.CommandTimeout = 65535;
-                    cmd.ExecuteNonQuery();
-                }
-            }
+            var sqlQueryExecutor = new SqlQueryExecutor();
+            sqlQueryExecutor.Execute(sqlQuery);
 
             return Task.CompletedTask;
         }

--- a/src/ScaleUnitManagement/ScaleUnitFeatureManager/Common/RunDBSync.cs
+++ b/src/ScaleUnitManagement/ScaleUnitFeatureManager/Common/RunDBSync.cs
@@ -27,23 +27,23 @@ namespace ScaleUnitManagement.ScaleUnitFeatureManager.Common
 
                 string dbSyncTool = Path.Combine(scaleUnit.ServiceVolume, @"AOSService\PackagesLocalDirectory\bin\syncengine.exe");
                 string metaBinariesPath = Path.Combine(scaleUnit.ServiceVolume, @"AOSService\PackagesLocalDirectory");
+                string outputFile = $"{scaleUnit.AxDbName}_DbSync.log";
 
-                string cmd =
-                    dbSyncTool
-                    + " -syncmode=" + CommandExecutor.Quotes + "fullall" + CommandExecutor.Quotes
-                    + " -metadatabinaries=" + CommandExecutor.Quotes + metaBinariesPath + CommandExecutor.Quotes
-                    + " -connect=" + CommandExecutor.Quotes + $"Data Source=localhost;Initial Catalog={scaleUnit.AxDbName};Integrated Security=True;Enlist=True;Application Name=AXVSSDK" + CommandExecutor.Quotes
-                    + " -verbosity=" + CommandExecutor.Quotes + "Diagnostic" + CommandExecutor.Quotes
-                    + " -scaleUnitOptionsAsJson=" + CommandExecutor.Quotes + "{" + CommandExecutor.Quotes + "IsScaleUnitFeatureEnabled" + CommandExecutor.Quotes + ": true, " + CommandExecutor.Quotes + "scaleUnitMnemonics" + CommandExecutor.Quotes + ":" + $"'{scaleUnit.ScaleUnitId}'" + " }" + CommandExecutor.Quotes
-                    + " -triggerOptionsAsJson=" + CommandExecutor.Quotes + "{" + CommandExecutor.Quotes + "IsEnabled" + CommandExecutor.Quotes + ": true}" + CommandExecutor.Quotes
-                    + $" > {scaleUnit.AxDbName}_DbSync.log";
+                string args =
+                    "-syncmode=\"fullall\""
+                    + $" -metadatabinaries=\"{metaBinariesPath}\""
+                    + $" -connect=\"Data Source=localhost;Initial Catalog={scaleUnit.AxDbName};Integrated Security=True;Enlist=True;Application Name=AXVSSDK\""
+                    + " -verbosity=\"Diagnostic\""
+                    + " -scaleUnitOptionsAsJson=\"{\"IsScaleUnitFeatureEnabled\": true, \"scaleUnitMnemonics\":" + $"'{scaleUnit.ScaleUnitId}'" + " }\""
+                    + " -triggerOptionsAsJson=\"{\"IsEnabled\": true}\"";
 
-                Console.WriteLine(cmd);
+                Console.WriteLine($"{dbSyncTool} {args} > {outputFile}");
 
                 Console.WriteLine("\nDBSync started at: " + DateTime.UtcNow + ", this will take approximately 30 minutes.\n");
 
-                CommandExecutor ce = new CommandExecutor();
-                ce.RunCommand(cmd);
+                CommandExecutor ce = new CommandExecutor(dbSyncTool, args);
+                ce.AddOutputFile(outputFile);
+                ce.RunCommand();
 
                 Console.WriteLine("\nDBSync finished \n");
             }

--- a/src/ScaleUnitManagement/ScaleUnitFeatureManager/Hub/AddMESFeatureFlight.cs
+++ b/src/ScaleUnitManagement/ScaleUnitFeatureManager/Hub/AddMESFeatureFlight.cs
@@ -1,4 +1,3 @@
-using System.Data.SqlClient;
 using System.Threading.Tasks;
 using ScaleUnitManagement.Utilities;
 
@@ -30,16 +29,8 @@ namespace ScaleUnitManagement.ScaleUnitFeatureManager.Hub
                 INSERT INTO SysFlighting (FlightName, Enabled, FlightServiceId) VALUES ('{MESFlightName}', 1, 12719367);
             ";
 
-            string connectionString = $"Data Source=localhost;Initial Catalog={scaleUnit.AxDbName};Integrated Security=True;Enlist=True;Application Name=ScaleUnitDevTool";
-            using (SqlConnection conn = new SqlConnection(connectionString))
-            {
-                using (SqlCommand cmd = new SqlCommand(sqlQuery, conn))
-                {
-                    conn.Open();
-                    cmd.CommandTimeout = 65535;
-                    cmd.ExecuteNonQuery();
-                }
-            }
+            var sqlQueryExecutor = new Utilities.SqlQueryExecutor();
+            sqlQueryExecutor.Execute(sqlQuery);
 
             return Task.CompletedTask;
         }

--- a/src/ScaleUnitManagement/ScaleUnitFeatureManager/Hub/EnableNumberSequenceTableChangeTracking.cs
+++ b/src/ScaleUnitManagement/ScaleUnitFeatureManager/Hub/EnableNumberSequenceTableChangeTracking.cs
@@ -1,5 +1,5 @@
-using System.Data.SqlClient;
 using System.Threading.Tasks;
+using ScaleUnitManagement.ScaleUnitFeatureManager.Utilities;
 using ScaleUnitManagement.Utilities;
 
 namespace ScaleUnitManagement.ScaleUnitFeatureManager.Hub
@@ -21,21 +21,13 @@ namespace ScaleUnitManagement.ScaleUnitFeatureManager.Hub
             ScaleUnitInstance scaleUnit = Config.FindScaleUnitWithId(ScaleUnitContext.GetScaleUnitId());
 
             string sqlQuery = $@"
-USE {scaleUnit.AxDbName};
-IF NOT EXISTS (SELECT TOP 1 1 FROM sys.change_tracking_tables WHERE object_id = OBJECT_ID('NumberSequenceTable'))
-	ALTER TABLE dbo.NumberSequenceTable ENABLE CHANGE_TRACKING WITH (TRACK_COLUMNS_UPDATED = ON)
-";
+            USE {scaleUnit.AxDbName};
+            IF NOT EXISTS (SELECT TOP 1 1 FROM sys.change_tracking_tables WHERE object_id = OBJECT_ID('NumberSequenceTable'))
+	            ALTER TABLE dbo.NumberSequenceTable ENABLE CHANGE_TRACKING WITH (TRACK_COLUMNS_UPDATED = ON)
+            ";
 
-            string connectionString = $"Data Source=localhost;Initial Catalog={scaleUnit.AxDbName};Integrated Security=True;Enlist=True;Application Name=ScaleUnitDevTool";
-            using (SqlConnection conn = new SqlConnection(connectionString))
-            {
-                using (SqlCommand cmd = new SqlCommand(sqlQuery, conn))
-                {
-                    conn.Open();
-                    cmd.CommandTimeout = 65535;
-                    cmd.ExecuteNonQuery();
-                }
-            }
+            var sqlQueryExecutor = new SqlQueryExecutor();
+            sqlQueryExecutor.Execute(sqlQuery);
 
             return Task.CompletedTask;
         }

--- a/src/ScaleUnitManagement/ScaleUnitFeatureManager/Hub/EnableNumberSequenceTableChangeTracking.cs
+++ b/src/ScaleUnitManagement/ScaleUnitFeatureManager/Hub/EnableNumberSequenceTableChangeTracking.cs
@@ -1,5 +1,5 @@
+using System.Data.SqlClient;
 using System.Threading.Tasks;
-using ScaleUnitManagement.ScaleUnitFeatureManager.Utilities;
 using ScaleUnitManagement.Utilities;
 
 namespace ScaleUnitManagement.ScaleUnitFeatureManager.Hub
@@ -26,10 +26,16 @@ IF NOT EXISTS (SELECT TOP 1 1 FROM sys.change_tracking_tables WHERE object_id = 
 	ALTER TABLE dbo.NumberSequenceTable ENABLE CHANGE_TRACKING WITH (TRACK_COLUMNS_UPDATED = ON)
 ";
 
-            string cmd = "Invoke-Sqlcmd -Query " + CommandExecutor.Quotes + sqlQuery + CommandExecutor.Quotes + " -QueryTimeout 65535";
-
-            CommandExecutor ce = new CommandExecutor();
-            ce.RunCommand(cmd);
+            string connectionString = $"Data Source=localhost;Initial Catalog={scaleUnit.AxDbName};Integrated Security=True;Enlist=True;Application Name=ScaleUnitDevTool";
+            using (SqlConnection conn = new SqlConnection(connectionString))
+            {
+                using (SqlCommand cmd = new SqlCommand(sqlQuery, conn))
+                {
+                    conn.Open();
+                    cmd.CommandTimeout = 65535;
+                    cmd.ExecuteNonQuery();
+                }
+            }
 
             return Task.CompletedTask;
         }

--- a/src/ScaleUnitManagement/ScaleUnitFeatureManager/ScaleUnit/ClearProblematicTables.cs
+++ b/src/ScaleUnitManagement/ScaleUnitFeatureManager/ScaleUnit/ClearProblematicTables.cs
@@ -1,5 +1,5 @@
+using System.Data.SqlClient;
 using System.Threading.Tasks;
-using ScaleUnitManagement.ScaleUnitFeatureManager.Utilities;
 using ScaleUnitManagement.Utilities;
 
 namespace ScaleUnitManagement.ScaleUnitFeatureManager.ScaleUnit
@@ -21,23 +21,29 @@ namespace ScaleUnitManagement.ScaleUnitFeatureManager.ScaleUnit
             ScaleUnitInstance scaleUnit = Config.FindScaleUnitWithId(ScaleUnitContext.GetScaleUnitId());
 
             string sqlQuery = $@"
-USE {scaleUnit.AxDbName};
-EXEC sys.sp_set_session_context @key = N'ActiveScaleUnitId', @value = '';
+            USE {scaleUnit.AxDbName};
+            EXEC sys.sp_set_session_context @key = N'ActiveScaleUnitId', @value = '';
 
-DELETE FROM SysFeatureStateV0;
-DELETE FROM FeatureManagementState;
-DELETE FROM FeatureManagementMetadata;
-DELETE FROM SysFlighting;
+            DELETE FROM SysFeatureStateV0;
+            DELETE FROM FeatureManagementState;
+            DELETE FROM FeatureManagementMetadata;
+            DELETE FROM SysFlighting;
 
-TRUNCATE TABLE NumberSequenceScope;
+            TRUNCATE TABLE NumberSequenceScope;
 
-EXEC sys.sp_set_session_context @key = N'ActiveScaleUnitId', @value = '@A';
-";
+            EXEC sys.sp_set_session_context @key = N'ActiveScaleUnitId', @value = '@A';
+            ";
 
-            string cmd = "Invoke-Sqlcmd -Query " + CommandExecutor.Quotes + sqlQuery + CommandExecutor.Quotes + " -QueryTimeout 65535";
-
-            CommandExecutor ce = new CommandExecutor();
-            ce.RunCommand(cmd);
+            string connectionString = $"Data Source=localhost;Initial Catalog={scaleUnit.AxDbName};Integrated Security=True;Enlist=True;Application Name=ScaleUnitDevTool";
+            using (SqlConnection conn = new SqlConnection(connectionString))
+            {
+                using (SqlCommand cmd = new SqlCommand(sqlQuery, conn))
+                {
+                    conn.Open();
+                    cmd.CommandTimeout = 65535;
+                    cmd.ExecuteNonQuery();
+                }
+            }
 
             return Task.CompletedTask;
         }

--- a/src/ScaleUnitManagement/ScaleUnitFeatureManager/ScaleUnit/ClearProblematicTables.cs
+++ b/src/ScaleUnitManagement/ScaleUnitFeatureManager/ScaleUnit/ClearProblematicTables.cs
@@ -1,5 +1,5 @@
-using System.Data.SqlClient;
 using System.Threading.Tasks;
+using ScaleUnitManagement.ScaleUnitFeatureManager.Utilities;
 using ScaleUnitManagement.Utilities;
 
 namespace ScaleUnitManagement.ScaleUnitFeatureManager.ScaleUnit
@@ -34,16 +34,8 @@ namespace ScaleUnitManagement.ScaleUnitFeatureManager.ScaleUnit
             EXEC sys.sp_set_session_context @key = N'ActiveScaleUnitId', @value = '@A';
             ";
 
-            string connectionString = $"Data Source=localhost;Initial Catalog={scaleUnit.AxDbName};Integrated Security=True;Enlist=True;Application Name=ScaleUnitDevTool";
-            using (SqlConnection conn = new SqlConnection(connectionString))
-            {
-                using (SqlCommand cmd = new SqlCommand(sqlQuery, conn))
-                {
-                    conn.Open();
-                    cmd.CommandTimeout = 65535;
-                    cmd.ExecuteNonQuery();
-                }
-            }
+            var sqlQueryExecutor = new SqlQueryExecutor();
+            sqlQueryExecutor.Execute(sqlQuery);
 
             return Task.CompletedTask;
         }

--- a/src/ScaleUnitManagement/ScaleUnitFeatureManager/ScaleUnit/ConfigureScaleUnit.cs
+++ b/src/ScaleUnitManagement/ScaleUnitFeatureManager/ScaleUnit/ConfigureScaleUnit.cs
@@ -84,8 +84,8 @@ namespace ScaleUnitManagement.ScaleUnitFeatureManager.ScaleUnit
                 New-Service -Name '{scaleUnit.BatchServiceName()}' -BinaryPathName '{scaleUnit.DynamicsBatchExePath()} -service {scaleUnit.WebConfigPath()}' -credential $creds -startupType Manual;
             ";
 
-            CommandExecutor ce = new CommandExecutor();
-            ce.RunCommand(cmd);
+            CommandExecutor ce = new CommandExecutor(cmd);
+            ce.RunCommand();
         }
     }
 }

--- a/src/ScaleUnitManagement/ScaleUnitFeatureManager/ScaleUnit/EnableDbChangeTracking.cs
+++ b/src/ScaleUnitManagement/ScaleUnitFeatureManager/ScaleUnit/EnableDbChangeTracking.cs
@@ -1,5 +1,5 @@
-using System.Data.SqlClient;
 using System.Threading.Tasks;
+using ScaleUnitManagement.ScaleUnitFeatureManager.Utilities;
 using ScaleUnitManagement.Utilities;
 
 namespace ScaleUnitManagement.ScaleUnitFeatureManager.ScaleUnit
@@ -22,16 +22,8 @@ namespace ScaleUnitManagement.ScaleUnitFeatureManager.ScaleUnit
 
             string sqlQuery = $"USE master; IF NOT EXISTS (SELECT * FROM sys.change_tracking_databases WHERE database_id=DB_ID('{scaleUnit.AxDbName}')) ALTER DATABASE {scaleUnit.AxDbName} SET CHANGE_TRACKING = ON(CHANGE_RETENTION = 2 DAYS, AUTO_CLEANUP = ON)";
 
-            string connectionString = $"Data Source=localhost;Initial Catalog={scaleUnit.AxDbName};Integrated Security=True;Enlist=True;Application Name=ScaleUnitDevTool";
-            using (SqlConnection conn = new SqlConnection(connectionString))
-            {
-                using (SqlCommand cmd = new SqlCommand(sqlQuery, conn))
-                {
-                    conn.Open();
-                    cmd.CommandTimeout = 65535;
-                    cmd.ExecuteNonQuery();
-                }
-            }
+            var sqlQueryExecutor = new SqlQueryExecutor();
+            sqlQueryExecutor.Execute(sqlQuery);
 
             return Task.CompletedTask;
         }

--- a/src/ScaleUnitManagement/ScaleUnitFeatureManager/ScaleUnit/EnableDbChangeTracking.cs
+++ b/src/ScaleUnitManagement/ScaleUnitFeatureManager/ScaleUnit/EnableDbChangeTracking.cs
@@ -1,5 +1,5 @@
+using System.Data.SqlClient;
 using System.Threading.Tasks;
-using ScaleUnitManagement.ScaleUnitFeatureManager.Utilities;
 using ScaleUnitManagement.Utilities;
 
 namespace ScaleUnitManagement.ScaleUnitFeatureManager.ScaleUnit
@@ -21,10 +21,17 @@ namespace ScaleUnitManagement.ScaleUnitFeatureManager.ScaleUnit
             ScaleUnitInstance scaleUnit = Config.FindScaleUnitWithId(ScaleUnitContext.GetScaleUnitId());
 
             string sqlQuery = $"USE master; IF NOT EXISTS (SELECT * FROM sys.change_tracking_databases WHERE database_id=DB_ID('{scaleUnit.AxDbName}')) ALTER DATABASE {scaleUnit.AxDbName} SET CHANGE_TRACKING = ON(CHANGE_RETENTION = 2 DAYS, AUTO_CLEANUP = ON)";
-            string cmd = "Invoke-Sqlcmd -Query " + CommandExecutor.Quotes + sqlQuery + CommandExecutor.Quotes + " -QueryTimeout 65535";
 
-            CommandExecutor ce = new CommandExecutor();
-            ce.RunCommand(cmd);
+            string connectionString = $"Data Source=localhost;Initial Catalog={scaleUnit.AxDbName};Integrated Security=True;Enlist=True;Application Name=ScaleUnitDevTool";
+            using (SqlConnection conn = new SqlConnection(connectionString))
+            {
+                using (SqlCommand cmd = new SqlCommand(sqlQuery, conn))
+                {
+                    conn.Open();
+                    cmd.CommandTimeout = 65535;
+                    cmd.ExecuteNonQuery();
+                }
+            }
 
             return Task.CompletedTask;
         }

--- a/src/ScaleUnitManagement/ScaleUnitFeatureManager/Utilities/CertificateStoreHelper.cs
+++ b/src/ScaleUnitManagement/ScaleUnitFeatureManager/Utilities/CertificateStoreHelper.cs
@@ -83,8 +83,8 @@ namespace ScaleUnitManagement.ScaleUnitFeatureManager.Utilities
                 + "," + CommandExecutor.Quotes + "2.5.29.37={critical}{text}1.3.6.1.5.5.7.3.1" + CommandExecutor.Quotes
                 + "," + CommandExecutor.Quotes + "2.5.29.17={critical}{text}DNS=" + certificateSubject + CommandExecutor.Quotes + ")";
 
-            CommandExecutor ce = new CommandExecutor();
-            ce.RunCommand(cmd);
+            CommandExecutor ce = new CommandExecutor(cmd);
+            ce.RunCommand();
         }
 
         internal static string PersonalCertificateStoreName => "MY";

--- a/src/ScaleUnitManagement/ScaleUnitFeatureManager/Utilities/CommandExecutor.cs
+++ b/src/ScaleUnitManagement/ScaleUnitFeatureManager/Utilities/CommandExecutor.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 
 namespace ScaleUnitManagement.ScaleUnitFeatureManager.Utilities
 {
@@ -21,16 +22,14 @@ namespace ScaleUnitManagement.ScaleUnitFeatureManager.Utilities
             process = BuildProcess(executable, arguments);
         }
 
-        public void RunCommand()
-        {
-            List<int> defaultExitCodes = new List<int>();
-            defaultExitCodes.Add(0);
-            RunCommand(defaultExitCodes);
-        }
-
-        public void RunCommand(List<int> successCodes)
+        public void RunCommand(params int[] successCodes)
         {
             RunProcess();
+
+            if (successCodes.Length == 0)
+            {
+                successCodes = new[] { 0 };
+            }
 
             if (!successCodes.Contains(process.ExitCode))
                 throw new Exception($"Command: {process.StartInfo.FileName} {process.StartInfo.Arguments}");

--- a/src/ScaleUnitManagement/ScaleUnitFeatureManager/Utilities/IISAdministrationHelper.cs
+++ b/src/ScaleUnitManagement/ScaleUnitFeatureManager/Utilities/IISAdministrationHelper.cs
@@ -133,7 +133,7 @@ namespace ScaleUnitManagement.ScaleUnitFeatureManager.Utilities
                 $@"robocopy {Config.HubScaleUnit().SiteRoot()} {scaleUnit.SiteRoot()} /MIR /MT /log+:{robocopyLogPath};";
 
             CommandExecutor ce = new CommandExecutor(cmd);
-            ce.RunCommand(new int[] { 0, 1 });
+            ce.RunCommand(0, 1);
         }
     }
 }

--- a/src/ScaleUnitManagement/ScaleUnitFeatureManager/Utilities/IISAdministrationHelper.cs
+++ b/src/ScaleUnitManagement/ScaleUnitFeatureManager/Utilities/IISAdministrationHelper.cs
@@ -133,7 +133,7 @@ namespace ScaleUnitManagement.ScaleUnitFeatureManager.Utilities
                 $@"robocopy {Config.HubScaleUnit().SiteRoot()} {scaleUnit.SiteRoot()} /MIR /MT /log+:{robocopyLogPath};";
 
             CommandExecutor ce = new CommandExecutor(cmd);
-            ce.RunCommand(new List<int>() { 0, 1 });
+            ce.RunCommand(new int[] { 0, 1 });
         }
     }
 }

--- a/src/ScaleUnitManagement/ScaleUnitFeatureManager/Utilities/IISAdministrationHelper.cs
+++ b/src/ScaleUnitManagement/ScaleUnitFeatureManager/Utilities/IISAdministrationHelper.cs
@@ -132,8 +132,8 @@ namespace ScaleUnitManagement.ScaleUnitFeatureManager.Utilities
             string cmd =
                 $@"robocopy {Config.HubScaleUnit().SiteRoot()} {scaleUnit.SiteRoot()} /MIR /MT /log+:{robocopyLogPath};";
 
-            CommandExecutor ce = new CommandExecutor();
-            ce.RunCommand(cmd, new List<int>() { 0, 1 });
+            CommandExecutor ce = new CommandExecutor(cmd);
+            ce.RunCommand(new List<int>() { 0, 1 });
         }
     }
 }

--- a/src/ScaleUnitManagement/ScaleUnitFeatureManager/Utilities/SqlQueryExecutor.cs
+++ b/src/ScaleUnitManagement/ScaleUnitFeatureManager/Utilities/SqlQueryExecutor.cs
@@ -1,0 +1,27 @@
+using System.Data.SqlClient;
+using ScaleUnitManagement.Utilities;
+
+namespace ScaleUnitManagement.ScaleUnitFeatureManager.Utilities
+{
+    public class SqlQueryExecutor
+    {
+        private readonly ScaleUnitInstance scaleUnit;
+
+        public SqlQueryExecutor()
+        {
+            scaleUnit = Config.FindScaleUnitWithId(ScaleUnitContext.GetScaleUnitId());
+        }
+
+        public void Execute(string query)
+        {
+            string connectionString = $"Data Source=localhost;Initial Catalog={scaleUnit.AxDbName};Integrated Security=True;Enlist=True;Application Name=ScaleUnitDevTool";
+            using (SqlConnection conn = new SqlConnection(connectionString))
+            using (SqlCommand cmd = new SqlCommand(query, conn))
+            {
+                conn.Open();
+                cmd.CommandTimeout = 65535;
+                cmd.ExecuteNonQuery();
+            }
+        }
+    }
+}

--- a/src/ScaleUnitManagement/ScaleUnitFeatureManager/Utilities/WebConfig.cs
+++ b/src/ScaleUnitManagement/ScaleUnitFeatureManager/Utilities/WebConfig.cs
@@ -75,10 +75,8 @@ namespace ScaleUnitManagement.ScaleUnitFeatureManager.Utilities
             doc.Save(webConfigPath);
 
             //Encrypt config file
-            string encryptConfigFileCommand = configEncryptorExePath + " -encrypt " + webConfigPath;
-
-            CommandExecutor ce = new CommandExecutor();
-            ce.RunCommand(encryptConfigFileCommand);
+            CommandExecutor ce = new CommandExecutor(configEncryptorExePath, "-encrypt " + webConfigPath);
+            ce.RunCommand();
         }
     }
 }

--- a/src/ScaleUnitManagement/ScaleUnitManagement.csproj
+++ b/src/ScaleUnitManagement/ScaleUnitManagement.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="FluentAssertions" Version="6.0.0-alpha0001" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.8" />
     <PackageReference Include="Microsoft.Web.Administration" Version="11.1.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
CommandExecutor can now execute commands without PowerShell using `Process.Start`.
`Invoke-SqlCmd` has been removed. Instead `SqlCommand` is used to query the database.

Resolves remaining items on #10 