### PR TITLE
Fixing movement of workloads

### DIFF
--- a/src/CLI/MoveWorkloads.cs
+++ b/src/CLI/MoveWorkloads.cs
@@ -29,9 +29,6 @@ namespace CLI
 
         private static async Task MoveWorkloadsFromScaleUnitToHub(ScaleUnitInstance scaleUnit)
         {
-            List<ScaleUnitInstance> scaleUnitInstances = Config.ScaleUnitInstances();
-            scaleUnitInstances.Sort();
-
             using (var context = ScaleUnitContext.CreateContext(scaleUnit.ScaleUnitId))
             {
                 string hubId = "@@";


### PR DESCRIPTION
The scale units were being sorted while the program was iterating through them. The sort was unnecessary, so it has been removed to fix the issue. This has been tested by running all the local tests and manually setting up, installing and moving workloads in a singleOneBoxEnvironment.
#patch
resolves #73 