### PR TITLE
Close output file after process has exited

### DIFF
--- a/src/ScaleUnitManagement/ScaleUnitFeatureManager/Utilities/CommandExecutor.cs
+++ b/src/ScaleUnitManagement/ScaleUnitFeatureManager/Utilities/CommandExecutor.cs
@@ -57,6 +57,10 @@ namespace ScaleUnitManagement.ScaleUnitFeatureManager.Utilities
                     outputStream.WriteLine(e.Data);
                 }
             });
+            process.Exited += new EventHandler((sender, e) =>
+            {
+                outputStream.Close();
+            });
         }
 
         private void RunProcess()


### PR DESCRIPTION
Processes with output files had streams that were not closed after running the process. This caused errors when trying to write to the same file twice. Tested manually on a SingleOneBox environment.
Resolves #80 
#patch