### PR TITLE
Make seperate API write request for every workload

### DIFF
--- a/src/ScaleUnitManagement/WorkloadSetupOrchestrator/HubWorkloadInstaller.cs
+++ b/src/ScaleUnitManagement/WorkloadSetupOrchestrator/HubWorkloadInstaller.cs
@@ -51,7 +51,11 @@ namespace ScaleUnitManagement.WorkloadSetupOrchestrator
             await ReliableRun.Execute(async () =>
             {
                 List<WorkloadInstance> workloadInstances = await new WorkloadInstanceManager(aosClient).CreateWorkloadInstances();
-                List<WorkloadInstance> createdInstances = await aosClient.WriteWorkloadInstances(workloadInstances);
+                List<WorkloadInstance> createdInstances = new List<WorkloadInstance>();
+                foreach (var workloadInstance in workloadInstances)
+                {
+                    createdInstances.AddRange(await aosClient.WriteWorkloadInstances(workloadInstances));
+                }
 
                 this.ValidateCreatedWorkloadInstances(workloadInstances, createdInstances);
             }, "Install workloads on hub");

--- a/src/ScaleUnitManagement/WorkloadSetupOrchestrator/HubWorkloadInstaller.cs
+++ b/src/ScaleUnitManagement/WorkloadSetupOrchestrator/HubWorkloadInstaller.cs
@@ -54,7 +54,7 @@ namespace ScaleUnitManagement.WorkloadSetupOrchestrator
                 List<WorkloadInstance> createdInstances = new List<WorkloadInstance>();
                 foreach (var workloadInstance in workloadInstances)
                 {
-                    createdInstances.AddRange(await aosClient.WriteWorkloadInstances(workloadInstances));
+                    createdInstances = await aosClient.WriteWorkloadInstances(new List<WorkloadInstance> { workloadInstance });
                 }
 
                 this.ValidateCreatedWorkloadInstances(workloadInstances, createdInstances);

--- a/src/ScaleUnitManagement/WorkloadSetupOrchestrator/WorkloadMover.cs
+++ b/src/ScaleUnitManagement/WorkloadSetupOrchestrator/WorkloadMover.cs
@@ -31,7 +31,7 @@ namespace ScaleUnitManagement.WorkloadSetupOrchestrator
                     }
                     workloadInstance.ExecutingEnvironment.Add(CreateTemporalAssignment(moveToId, movementDateTime));
                 }
-                await aosClient.WriteWorkloadInstances(workloadInstances);
+                await Task.WhenAll(workloadInstances.Select(workload => aosClient.WriteWorkloadInstances(new List<WorkloadInstance> { workload })));
             }, $"Move workloads from scaleUnit {scaleUnit.ScaleUnitId} to hub");
         }
 

--- a/src/ScaleUnitManagement/WorkloadSetupOrchestrator/WorkloadMover.cs
+++ b/src/ScaleUnitManagement/WorkloadSetupOrchestrator/WorkloadMover.cs
@@ -30,8 +30,9 @@ namespace ScaleUnitManagement.WorkloadSetupOrchestrator
                         }
                     }
                     workloadInstance.ExecutingEnvironment.Add(CreateTemporalAssignment(moveToId, movementDateTime));
+
+                    await aosClient.WriteWorkloadInstances(new List<WorkloadInstance> { workloadInstance });
                 }
-                await Task.WhenAll(workloadInstances.Select(workload => aosClient.WriteWorkloadInstances(new List<WorkloadInstance> { workload })));
             }, $"Move workloads from scaleUnit {scaleUnit.ScaleUnitId} to hub");
         }
 


### PR DESCRIPTION
Asynchronously make an API request for every workloadInstance when writing workloads, instead of writing all of them at the same time. Manually tested in the SingleOneBox environment.
closes #82 
#patch