### PR TITLE
Add capability to import workloads from different Azure Storage

### DIFF
--- a/src/CLI/SetupTools.cs
+++ b/src/CLI/SetupTools.cs
@@ -15,6 +15,7 @@ namespace CLI
             options.Add(new CLIOption() { Name = "Disable scale unit feature and remove triggers", Command = DisableScaleUnitFeature.Show });
             options.Add(new CLIOption() { Name = "Update scale unit id", Command = UpdateScaleUnitId.Show });
             options.Add(new CLIOption() { Name = "Clean up Azure storage account for a scale unit", Command = CleanUpStorageAccount.Show });
+            options.Add(new CLIOption() { Name = "Import workloads from Azure storage blob with SAS url", Command = ImportWorkloadBlob.Show });
 
             var screen = new CLIScreen(options, selectionHistory, "Please select the operation you want to perform:\n", "\nOperation to perform: ");
             await CLIMenu.ShowScreen(screen);

--- a/src/CLI/SetupToolsOptions/CleanUpStorageAccount.cs
+++ b/src/CLI/SetupToolsOptions/CleanUpStorageAccount.cs
@@ -30,8 +30,8 @@ namespace CLI.SetupToolsOptions
         {
             using (var context = ScaleUnitContext.CreateContext(sortedScaleUnits[input - 1].ScaleUnitId))
             {
-                var accountCleaner = new StorageAccountManager();
-                await accountCleaner.CleanStorageAccount();
+                var storageAccountManager = new StorageAccountManager();
+                await storageAccountManager.CleanStorageAccount();
             }
 
             Console.WriteLine("Done");

--- a/src/CLI/SetupToolsOptions/CleanUpStorageAccount.cs
+++ b/src/CLI/SetupToolsOptions/CleanUpStorageAccount.cs
@@ -30,7 +30,7 @@ namespace CLI.SetupToolsOptions
         {
             using (var context = ScaleUnitContext.CreateContext(sortedScaleUnits[input - 1].ScaleUnitId))
             {
-                var accountCleaner = new StorageAccountCleaner();
+                var accountCleaner = new StorageAccountManager();
                 await accountCleaner.CleanStorageAccount();
             }
 

--- a/src/CLI/SetupToolsOptions/ImportWorkloadBlob.cs
+++ b/src/CLI/SetupToolsOptions/ImportWorkloadBlob.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using CLIFramework;
+using ScaleUnitManagement.Utilities;
+using ScaleUnitManagement.ScaleUnitFeatureManager.Common;
+using System;
+
+namespace CLI.SetupToolsOptions
+{
+    internal class ImportWorkloadBlob
+    {
+        private static List<ScaleUnitInstance> sortedScaleUnits;
+
+        public static async Task Show(int input, string selectionHistory)
+        {
+            var options = new List<CLIOption>();
+            sortedScaleUnits = Config.ScaleUnitInstances();
+            sortedScaleUnits.Sort();
+
+            foreach (var scaleUnit in sortedScaleUnits)
+            {
+                options.Add(new CLIOption() { Name = scaleUnit.PrintableName(), Command = ImportWorkloadBlobFromSasToken });
+            }
+
+            var screen = new CLIScreen(options, selectionHistory, "Please select the scale unit you would like to import workloads to:\n", "\nScale unit storage to import to: ");
+            await CLIMenu.ShowScreen(screen);
+        }
+
+        private static async Task ImportWorkloadBlobFromSasToken(int input, string selectionHistory)
+        {
+            var sasToken = CLIMenu.EnterValuePrompt("Please paste in the blob SAS URL for the blob storage that the workloads should be copied from:");
+            using (var context = ScaleUnitContext.CreateContext(sortedScaleUnits[input - 1].ScaleUnitId))
+            {
+                var accountCleaner = new StorageAccountManager();
+                try
+                {
+                    await accountCleaner.ImportWorkloadsBlob(sasToken);
+                    Console.WriteLine("Done");
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"An exception occured while importing blobs: {ex.Message}");
+                }
+            }
+
+        }
+    }
+}

--- a/src/CLI/SetupToolsOptions/ImportWorkloadBlob.cs
+++ b/src/CLI/SetupToolsOptions/ImportWorkloadBlob.cs
@@ -31,10 +31,10 @@ namespace CLI.SetupToolsOptions
             var sasToken = CLIMenu.EnterValuePrompt("Please paste in the blob SAS URL for the blob storage that the workloads should be copied from:");
             using (var context = ScaleUnitContext.CreateContext(sortedScaleUnits[input - 1].ScaleUnitId))
             {
-                var accountCleaner = new StorageAccountManager();
+                var storageAccountManager = new StorageAccountManager();
                 try
                 {
-                    await accountCleaner.ImportWorkloadsBlob(sasToken);
+                    await storageAccountManager.ImportWorkloadsBlob(sasToken);
                     Console.WriteLine("Done");
                 }
                 catch (Exception ex)

--- a/src/CLI/SetupToolsOptions/ImportWorkloadBlob.cs
+++ b/src/CLI/SetupToolsOptions/ImportWorkloadBlob.cs
@@ -28,7 +28,7 @@ namespace CLI.SetupToolsOptions
 
         private static async Task ImportWorkloadBlobFromSasToken(int input, string selectionHistory)
         {
-            var sasToken = CLIMenu.EnterValuePrompt("Please paste in the blob SAS URL for the blob storage that the workloads should be copied from:");
+            var sasToken = CLIMenu.EnterValuePrompt("Please paste in the blob SAS URL for the blob that the workloads should be copied from:");
             using (var context = ScaleUnitContext.CreateContext(sortedScaleUnits[input - 1].ScaleUnitId))
             {
                 var storageAccountManager = new StorageAccountManager();

--- a/src/CLIFramework/CLIMenu.cs
+++ b/src/CLIFramework/CLIMenu.cs
@@ -110,9 +110,7 @@ namespace CLIFramework
 
         public static bool YesNoPrompt(string message)
         {
-            Console.Write(message);
-            string input = Console.ReadLine().ToLower();
-
+            string input = EnterValuePrompt(message).ToLower();
             return String.IsNullOrEmpty(input) || input == "y" || input == "yes";
         }
 
@@ -122,5 +120,10 @@ namespace CLIFramework
             string input = Console.ReadLine();
         }
 
+        public static string EnterValuePrompt(string message)
+        {
+            Console.WriteLine(message);
+            return Console.ReadLine();
+        }
     }
 }

--- a/src/ScaleUnitManagement/WorkloadSetupOrchestrator/StorageAccountManager.cs
+++ b/src/ScaleUnitManagement/WorkloadSetupOrchestrator/StorageAccountManager.cs
@@ -39,10 +39,8 @@ namespace ScaleUnitManagement.ScaleUnitFeatureManager.Common
                 throw new Exception($"{sasUrlString} is not a valid Uri");
             }
 
-            BlobClientOptions options = null;
-            var sourceBlobClient = new BlobClient(sasUri, options);
-            var blobContainerName = sourceBlobClient.BlobContainerName;
-            var blobName = sourceBlobClient.Name;
+            var blobContainerName = "sysworkloadinstancesharedserviceunitstorage";
+            var blobName = "current.json";
 
             var targetBlobClient = new BlobClient(connectionString, blobContainerName, blobName);
 

--- a/src/ScaleUnitManagement/WorkloadSetupOrchestrator/StorageAccountManager.cs
+++ b/src/ScaleUnitManagement/WorkloadSetupOrchestrator/StorageAccountManager.cs
@@ -1,27 +1,60 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Azure;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Table;
 using ScaleUnitManagement.Utilities;
+using System;
 
 namespace ScaleUnitManagement.ScaleUnitFeatureManager.Common
 {
-    public class StorageAccountCleaner
+    public class StorageAccountManager
     {
-        private string connectionString;
+        private readonly string connectionString;
+
+        public StorageAccountManager()
+        {
+            var scaleUnit = Config.FindScaleUnitWithId(ScaleUnitContext.GetScaleUnitId());
+            connectionString = scaleUnit.AzureStorageConnectionString;
+        }
 
         public async Task CleanStorageAccount()
         {
-            ScaleUnitInstance scaleUnit = Config.FindScaleUnitWithId(ScaleUnitContext.GetScaleUnitId());
-            connectionString = scaleUnit.AzureStorageConnectionString;
-
             await DeleteBlobContainers();
+            await DeleteSharedTables();
+        }
 
-            await DeleteSharedTablesAsync();
+        public async Task ImportWorkloadsBlob(string sasUrlString)
+        {
+            Uri sasUri;
+            try
+            {
+                sasUri = new Uri(sasUrlString);
+            }
+            catch (Exception)
+            {
+                throw new Exception($"{sasUrlString} is not a valid Uri");
+            }
+
+            BlobClientOptions options = null;
+            var sourceBlobClient = new BlobClient(sasUri, options);
+            var blobContainerName = sourceBlobClient.BlobContainerName;
+            var blobName = sourceBlobClient.Name;
+
+            var targetBlobClient = new BlobClient(connectionString, blobContainerName, blobName);
+
+            var operation = await targetBlobClient.StartCopyFromUriAsync(sasUri);
+
+            await operation.WaitForCompletionAsync();
+
+            Response response = await operation.UpdateStatusAsync();
+            if (response.Status != 200)
+            {
+                throw new Exception($"\nAn error occured while copying the workloads to the blob: \n{response.Status}: {response.Content}");
+            }
         }
 
         private async Task DeleteBlobContainers()
@@ -42,7 +75,7 @@ namespace ScaleUnitManagement.ScaleUnitFeatureManager.Common
             }
         }
 
-        private async Task DeleteSharedTablesAsync()
+        private async Task DeleteSharedTables()
         {
             CloudStorageAccount storageAccount = CloudStorageAccount.Parse(connectionString);
             CloudTableClient tableClient = storageAccount.CreateCloudTableClient();


### PR DESCRIPTION
Using a SAS token, the user can copy an Azure blob into one of the scale unit containers.

Tested manually in the singleOneBox environment by importing workloads between hub and spoke, with SAS tokens created on the Azure Storage page.