### PR TITLE
Starting the W3SVC service in case it is stopped

### DIFF
--- a/src/ScaleUnitManagement/ScaleUnitFeatureManager/Utilities/IISAdministrationHelper.cs
+++ b/src/ScaleUnitManagement/ScaleUnitFeatureManager/Utilities/IISAdministrationHelper.cs
@@ -85,6 +85,7 @@ namespace ScaleUnitManagement.ScaleUnitFeatureManager.Utilities
 
                 if (site?.State == ObjectState.Stopped)
                 {
+                    ServiceHelper.StartService("W3SVC", TimeSpan.FromMinutes(1));
                     Console.WriteLine($"Starting IIS site {site.Name}..");
                     site.Start();
                     Console.WriteLine($"Successfully started IIS site {site.Name}");


### PR DESCRIPTION
When starting IIS site AOSServices, the IIS services must be running. This change will start it every time, and if it is already started it will just state that and move on.
#patch
closes #62 

After stopping the services and making sure that W3SVC is not running, this is the output:
![image](https://user-images.githubusercontent.com/43210147/132829985-79a17ccc-981e-4131-b13b-a4e7899003e6.png)
