### PR TITLE
Add assembly details, with tagged version on CI in main

### DIFF
--- a/.github/workflows/dotnet-core-release.yml
+++ b/.github/workflows/dotnet-core-release.yml
@@ -17,32 +17,41 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.301
-    - name: Publish CLI project
-      run: dotnet publish ./src/CLI/CLI.csproj --configuration Release --self-contained --runtime win-x64
-    - name: Bump version and push tag
+    - name: Bump version (without v-prefix)
       uses: anothrNick/github-tag-action@1.33.0
-      id: tag_action
+      id: v_less_dry_versioning_action
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        DRY_RUN: true # allows fetching the version number without a v-prefix (which would break msbuild)
+        WITH_V: false
+        RELEASE_BRANCHES: main
+        INITIAL_VERSION: 1.0.0
+    - name: Publish CLI project
+      run: dotnet publish ./src/CLI/CLI.csproj --configuration Release --self-contained --runtime win-x64 /p:Version=${{ steps.v_less_dry_versioning_action.outputs.new_tag }} /p:AssemblyVersion=${{ steps.v_less_dry_versioning_action.outputs.new_tag }}
+    - name: Bump version (with v-prefix) and push tag
+      uses: anothrNick/github-tag-action@1.33.0
+      id: versioning_action
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         WITH_V: true
         RELEASE_BRANCHES: main
         INITIAL_VERSION: 1.0.0
     - name: Zip published CLI binaries
-      run: zip -r -j ${{ steps.tag_action.outputs.tag }}.zip ./src/CLI/bin/Release/netcoreapp3.1/win-x64/publish
+      run: zip -r -j ${{ steps.versioning_action.outputs.tag }}.zip ./src/CLI/bin/Release/netcoreapp3.1/win-x64/publish
     - name: Create GitHub release
       uses: actions/create-release@v1.1.4
       id: create_release_action
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: ${{ steps.tag_action.outputs.tag }}
-        release_name: Release ${{ steps.tag_action.outputs.tag }}
+        tag_name: ${{ steps.versioning_action.outputs.tag }}
+        release_name: Release ${{ steps.versioning_action.outputs.tag }}
     - name: Upload published binaries to GitHub release
       uses: actions/upload-release-asset@v1.0.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release_action.outputs.upload_url }}
-        asset_path: ./${{ steps.tag_action.outputs.tag }}.zip
-        asset_name: ScaleUnitManagementTools_${{ steps.tag_action.outputs.tag }}.zip
+        asset_path: ./${{ steps.versioning_action.outputs.tag }}.zip
+        asset_name: ScaleUnitManagementTools_${{ steps.versioning_action.outputs.tag }}.zip
         asset_content_type: application/zip

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+  <PropertyGroup>
+    <Company>Microsoft</Company>
+    <Copyright>Microsoft</Copyright>
+    <Authors>Supply Chain Management, Cloud and Edge Team</Authors>
+    <Version>0.0.0</Version>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Looking into a customer environment, I noticed that our binaries are missing certain details that make debugging easier (versioning, for one).

This PR adds versioning and a few more details to assemblies generated for the releases and if built locally in VS.