### PR TITLE
Enable single execution deployment

### DIFF
--- a/src/CLI/ArgumentParser.cs
+++ b/src/CLI/ArgumentParser.cs
@@ -1,0 +1,44 @@
+using System;
+
+namespace CLI
+{
+    class ArgumentParser
+    {
+        public bool deploy = false;
+        public bool cleanStorage = false;
+        private bool[] matched;
+        private string[] arguments;
+
+        public void Parse(string[] args)
+        {
+            arguments = args;
+            matched = new bool[args.Length];
+            for (int i = 0; i < matched.Length; i++)
+            {
+                matched[i] = false;
+            }
+
+            deploy = ParseArgument("--deploy");
+            cleanStorage = ParseArgument("--clean-storage");
+
+            for (int i = 0; i < matched.Length; i++)
+            {
+                if (matched[i] == false)
+                {
+                    throw new Exception($"Did not recognize argument {args[i]}. Allowed arguments are \"--deploy\" and \"--clean-storage\"");
+                }
+            }
+        }
+
+        private bool ParseArgument(string argument)
+        {
+            var cliOption = Array.FindIndex(arguments, option => option.Equals(argument));
+            if (cliOption != -1)
+            {
+                matched[cliOption] = true;
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/src/CLI/Deployer.cs
+++ b/src/CLI/Deployer.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using ScaleUnitManagement.ScaleUnitFeatureManager.Common;
+using ScaleUnitManagement.ScaleUnitFeatureManager.Hub;
+using ScaleUnitManagement.ScaleUnitFeatureManager.ScaleUnit;
+using ScaleUnitManagement.ScaleUnitFeatureManager.Utilities;
+using ScaleUnitManagement.Utilities;
+using ScaleUnitManagement.WorkloadSetupOrchestrator;
+
+namespace CLI
+{
+    internal class Deployer
+    {
+        public async Task Deploy()
+        {
+            await InitializeEnvironments();
+            await PrepareEnvironments();
+            await InstallWorkloads();
+
+            Console.WriteLine("\nHub and spoke environments have been deployed successfully!\n");
+        }
+
+        public async Task CleanStorage()
+        {
+            foreach (ScaleUnitInstance scaleUnit in Config.ScaleUnitInstances())
+            {
+                Console.WriteLine($"\nCleaning environment on {scaleUnit.PrintableName()}");
+                using var context = ScaleUnitContext.CreateContext(scaleUnit.ScaleUnitId);
+                var storageAccountManager = new StorageAccountManager();
+                await storageAccountManager.CleanStorageAccount();
+            }
+        }
+
+        private async Task InitializeEnvironments()
+        {
+            foreach (ScaleUnitInstance scaleUnit in Config.ScaleUnitInstances())
+            {
+                Console.WriteLine($"\nInitializing environment on {scaleUnit.PrintableName()}");
+                using var context = ScaleUnitContext.CreateContext(scaleUnit.ScaleUnitId);
+                List<IStep> steps = GetSteps();
+                await RunSteps(steps);
+
+                Console.WriteLine($"\nAll initialization steps completed for {scaleUnit.PrintableName()}");
+            }
+        }
+
+        private List<IStep> GetSteps()
+        {
+            var sf = new StepFactory();
+            List<IStep> steps = sf.GetStepsOfType<ICommonStep>();
+            if (ScaleUnitContext.GetScaleUnitId() == "@@")
+            {
+                steps.AddRange(sf.GetStepsOfType<IHubStep>());
+            }
+            else
+            {
+                steps.AddRange(sf.GetStepsOfType<IScaleUnitStep>());
+            }
+            steps.Sort((x, y) => x.Priority().CompareTo(y.Priority()));
+            return steps;
+        }
+
+        private async Task RunSteps(List<IStep> steps)
+        {
+            for (int i = 0; i < steps.Count; i++)
+            {
+                try
+                {
+                    Console.WriteLine("\nExecuting step: " + steps[i].Label());
+                    await steps[i].Run();
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine($"Error occurred while enabling scale unit feature:\n{ex}");
+                }
+            }
+        }
+
+        private async Task PrepareEnvironments()
+        {
+            foreach (ScaleUnitInstance scaleUnit in Config.ScaleUnitInstances())
+            {
+                using var context = ScaleUnitContext.CreateContext(scaleUnit.ScaleUnitId);
+                Console.WriteLine($"\nPreparing {scaleUnit.PrintableName()} for installation");
+                if (scaleUnit.ScaleUnitId.Equals("@@"))
+                {
+                    await new HubConfigurationManager().Configure();
+                }
+                else
+                {
+                    await new ScaleUnitConfigurationManager().Configure();
+                }
+            }
+        }
+
+        private async Task InstallWorkloads()
+        {
+            Console.WriteLine("\nInstalling workloads on hub");
+            using (var context = ScaleUnitContext.CreateContext("@@"))
+            {
+                await new HubWorkloadInstaller().Install();
+            }
+
+            foreach (ScaleUnitInstance scaleUnit in Config.NonHubScaleUnitInstances())
+            {
+                using var context = ScaleUnitContext.CreateContext(scaleUnit.ScaleUnitId);
+                Console.WriteLine($"\nInstalling workloads on {scaleUnit.PrintableName()}");
+                await new ScaleUnitWorkloadInstaller().Install();
+            }
+        }
+    }
+}
+
+

--- a/src/CLI/Program.cs
+++ b/src/CLI/Program.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using CLIFramework;
 using ScaleUnitManagement.ScaleUnitFeatureManager.Utilities;
@@ -6,12 +7,38 @@ namespace CLI
 {
     public class Program
     {
-
         public static async Task Main(string[] args)
         {
             CheckForAdminAccess.ValidateCurrentUserIsProcessAdmin();
 
-            await CLIController.Run(new RootMenu());
+            if (args.Length == 0)
+            {
+                await CLIController.Run(new RootMenu());
+                return;
+            }
+
+            var arguments = new ArgumentParser();
+            try
+            {
+                arguments.Parse(args);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+                return;
+            }
+
+            var deployer = new Deployer();
+
+            if (arguments.cleanStorage)
+            {
+                await deployer.CleanStorage();
+            }
+
+            if (arguments.deploy)
+            {
+                await deployer.Deploy();
+            }
         }
     }
 }


### PR DESCRIPTION
Allows the user to run the tool with argument "--deploy", which runs all steps required for setting up hub and spoke. Also allows "--clean-storage", which will clean all Azure storage accounts. If no arguments are given, the program will run as usual.