### PR TITLE
Prune __dependentSystemMetadata from Workload

### DIFF
--- a/src/CloudAndEdgeLibs/FnOEnvironmentDeploymentMetadata.cs
+++ b/src/CloudAndEdgeLibs/FnOEnvironmentDeploymentMetadata.cs
@@ -1,4 +1,4 @@
-namespace CloudAndEdgeLibs
+namespace CloudAndEdgeLibs.Contracts
 {
     using System.Collections.Generic;
     using Newtonsoft.Json;

--- a/src/CloudAndEdgeLibs/FnOModelInfo.cs
+++ b/src/CloudAndEdgeLibs/FnOModelInfo.cs
@@ -1,4 +1,4 @@
-namespace CloudAndEdgeLibs
+namespace CloudAndEdgeLibs.Contracts
 {
     using System;
     using Newtonsoft.Json;

--- a/src/CloudAndEdgeLibs/Query.cs
+++ b/src/CloudAndEdgeLibs/Query.cs
@@ -1,4 +1,4 @@
-namespace CloudAndEdgeLibs
+namespace CloudAndEdgeLibs.Contracts
 {
     using Newtonsoft.Json;
 

--- a/src/CloudAndEdgeLibs/SystemMetadata.cs
+++ b/src/CloudAndEdgeLibs/SystemMetadata.cs
@@ -1,4 +1,4 @@
-namespace CloudAndEdgeLibs
+namespace CloudAndEdgeLibs.Contracts
 {
     using System;
     using System.Collections.Generic;

--- a/src/ScaleUnitManagement/Utilities/WorkloadExtensions.cs
+++ b/src/ScaleUnitManagement/Utilities/WorkloadExtensions.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using CloudAndEdgeLibs;
+using CloudAndEdgeLibs.Contracts;
+
+namespace ScaleUnitManagement.WorkloadSetupOrchestrator.Utilities
+{
+    public static class WorkloadExtensions
+    {
+        public static void PruneRedundancies(this List<Workload> workloads)
+        {
+            foreach (Workload workload in workloads)
+            {
+                workload.__DependentSystemMetadata = new SortedSet<SystemMetadata>();
+            }
+        }
+    }
+}

--- a/src/ScaleUnitManagement/WorkloadSetupOrchestrator/Utilities/WorkloadInstanceManager.cs
+++ b/src/ScaleUnitManagement/WorkloadSetupOrchestrator/Utilities/WorkloadInstanceManager.cs
@@ -28,6 +28,8 @@ namespace ScaleUnitManagement.WorkloadSetupOrchestrator.Utilities
             }
 
             List<Workload> workloads = await client.GetWorkloads();
+            workloads.PruneRedundancies();
+
             var workloadInstances = new List<WorkloadInstance>();
             var sysWorkloadInstances = new List<WorkloadInstance>();
 


### PR DESCRIPTION
Fixes #111.

Cuts ~10MB of unneeded data from a ~75MB workload instances file (~14% reduction).