### PR TITLE
Adds option to do emergency transition to hub

### DIFF
--- a/src/CLI/SetupTools.cs
+++ b/src/CLI/SetupTools.cs
@@ -16,6 +16,7 @@ namespace CLI
                 Option("Update scale unit id", new UpdateScaleUnitId().Show),
                 Option("Clean up Azure storage account for a scale unit", new CleanUpStorageAccount().Show),
                 Option("Import workloads from Azure storage blob with SAS url", new ImportWorkloadBlob().Show),
+                Option("Perform emergency transition from scale unit to hub", new TransitionToHub().Show)
             };
 
             var screen = new SingleSelectScreen(options, selectionHistory, "Please select the operation you want to perform:\n", "\nOperation to perform: ");

--- a/src/CLI/SetupTools.cs
+++ b/src/CLI/SetupTools.cs
@@ -16,7 +16,7 @@ namespace CLI
                 Option("Update scale unit id", new UpdateScaleUnitId().Show),
                 Option("Clean up Azure storage account for a scale unit", new CleanUpStorageAccount().Show),
                 Option("Import workloads from Azure storage blob with SAS url", new ImportWorkloadBlob().Show),
-                Option("Perform emergency transition from scale unit to hub", new TransitionToHub().Show)
+                Option("Perform emergency transition from scale unit to hub", new PerformEmergencyTransitionToHub().Show)
             };
 
             var screen = new SingleSelectScreen(options, selectionHistory, "Please select the operation you want to perform:\n", "\nOperation to perform: ");

--- a/src/CLI/SetupToolsOptions/PerformEmergencyTransitionToHub.cs
+++ b/src/CLI/SetupToolsOptions/PerformEmergencyTransitionToHub.cs
@@ -8,19 +8,19 @@ using ScaleUnitManagement.WorkloadSetupOrchestrator;
 
 namespace CLI.SetupToolsOptions
 {
-    internal class TransitionToHub : DevToolMenu
+    internal class PerformEmergencyTransitionToHub : DevToolMenu
     {
         public override async Task Show(int input, string selectionHistory)
         {
             List<ScaleUnitInstance> sortedNonHubScaleUnits = Config.NonHubScaleUnitInstances();
             sortedNonHubScaleUnits.Sort();
-            List<CLIOption> options = SelectScaleUnitOptions(sortedNonHubScaleUnits, RunTransition);
+            List<CLIOption> options = SelectScaleUnitOptions(sortedNonHubScaleUnits, PerformTransition);
 
             var screen = new SingleSelectScreen(options, selectionHistory, "\nSelect the scale unit where you want to perform emergency transition to hub:\n", "\nScale unit: ");
             await CLIController.ShowScreen(screen);
         }
 
-        private async Task RunTransition(int input, string selectionHistory)
+        private async Task PerformTransition(int input, string selectionHistory)
         {
             try
             {

--- a/src/CLI/SetupToolsOptions/TransitionToHub.cs
+++ b/src/CLI/SetupToolsOptions/TransitionToHub.cs
@@ -1,0 +1,37 @@
+using System.Threading.Tasks;
+using CLIFramework;
+using System;
+using ScaleUnitManagement.ScaleUnitFeatureManager.Common;
+using System.Collections.Generic;
+using ScaleUnitManagement.Utilities;
+using ScaleUnitManagement.WorkloadSetupOrchestrator;
+
+namespace CLI.SetupToolsOptions
+{
+    internal class TransitionToHub : DevToolMenu
+    {
+        public override async Task Show(int input, string selectionHistory)
+        {
+            List<ScaleUnitInstance> sortedNonHubScaleUnits = Config.NonHubScaleUnitInstances();
+            sortedNonHubScaleUnits.Sort();
+            List<CLIOption> options = SelectScaleUnitOptions(sortedNonHubScaleUnits, RunTransition);
+
+            var screen = new SingleSelectScreen(options, selectionHistory, "\nSelect the scale unit where you want to perform emergency transition to hub:\n", "\nScale unit: ");
+            await CLIController.ShowScreen(screen);
+        }
+
+        private async Task RunTransition(int input, string selectionHistory)
+        {
+            try
+            {
+                var workloadMover = new WorkloadMover();
+                await workloadMover.EmergencyTransitionToHub();
+                Console.WriteLine("Done");
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"An error occured while trying to run emergency transition to hub:\n{ex}");
+            }
+        }
+    }
+}

--- a/src/CLI/WorkloadMovementOptions/MoveWorkloads.cs
+++ b/src/CLI/WorkloadMovementOptions/MoveWorkloads.cs
@@ -30,10 +30,8 @@ namespace CLI.WorkloadMovementOptions
         {
             using var context = ScaleUnitContext.CreateContext(scaleUnit.ScaleUnitId);
             string hubId = "@@";
-            ScaleUnitInstance hub = Config.HubScaleUnit();
-            DateTime effectiveTime = DateTime.UtcNow.AddMinutes(5);
             var workloadMover = new WorkloadMover();
-            await workloadMover.MoveWorkloads(hubId, effectiveTime);
+            await workloadMover.MoveWorkloads(hubId);
         }
     }
 }

--- a/src/ScaleUnitManagementTests/MoveWorkloadsTest.cs
+++ b/src/ScaleUnitManagementTests/MoveWorkloadsTest.cs
@@ -30,7 +30,7 @@ namespace ScaleUnitManagementTests
             {
                 WorkloadMover workloadMover = new WorkloadMover();
                 workloadMover.SetScaleUnitAosClient(aosClient.Object);
-                await workloadMover.MoveWorkloads(hubId, DateTime.UtcNow);
+                await workloadMover.MoveWorkloads(hubId);
             }
 
             // Assert


### PR DESCRIPTION
Allows the user to select a scale unit that might be in a bad state and move everything from that scale unit to the hub, disregarding missing packages.
It has been tested that the movements are going through in AX.
Closes #107 