### PR TITLE
Set the blob name in sas uri

### DIFF
--- a/src/ScaleUnitManagement/WorkloadSetupOrchestrator/StorageAccountManager.cs
+++ b/src/ScaleUnitManagement/WorkloadSetupOrchestrator/StorageAccountManager.cs
@@ -52,7 +52,14 @@ namespace ScaleUnitManagement.ScaleUnitFeatureManager.Common
 
             var targetBlobClient = new BlobClient(connectionString, blobContainerName, blobName);
 
-            var operation = await targetBlobClient.StartCopyFromUriAsync(sasUri);
+            var blobUriBuilder = new BlobUriBuilder(sasUri)
+            {
+                BlobName = blobName
+            };
+            var blobUri = blobUriBuilder.ToUri();
+
+
+            var operation = await targetBlobClient.StartCopyFromUriAsync(blobUri);
 
             await operation.WaitForCompletionAsync();
 


### PR DESCRIPTION
When the sas uri is created for the container the blob name is not specified. By setting the blob name, the sas uri can still be used to copy the blob.

#patch
resolves #116 