### PR TITLE
Increase timeout to 20 minutes

### DIFF
--- a/src/ScaleUnitManagement/WorkloadSetupOrchestrator/Utilities/AOSClient.cs
+++ b/src/ScaleUnitManagement/WorkloadSetupOrchestrator/Utilities/AOSClient.cs
@@ -33,6 +33,7 @@ namespace ScaleUnitManagement.WorkloadSetupOrchestrator.Utilities
             {
                 BaseAddress = new Uri(scaleUnitInstance.Endpoint())
             };
+            httpClient.Timeout = TimeSpan.FromMinutes(20);
             httpClient.DefaultRequestHeaders.Add("Authorization", await OAuthHelper.GetAuthenticationHeader(aadTenant, aadClientAppId, aadClientAppSecret, aadResource));
 
             return new AOSClient(httpClient, scaleUnitInstance.AOSRequestPathPrefix());


### PR DESCRIPTION
Installing many large workloads can be very time consuming, and the AOS should not time out during these requests.

#patch