### PR TITLE
Allow choosing a specific environment to upgrade/drain/start workloads on

### DIFF
--- a/src/CLI/ManageWorkloadDataPipeline.cs
+++ b/src/CLI/ManageWorkloadDataPipeline.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using CLI.WorkloadDataPipelineOptions;
 using CLIFramework;
 using ScaleUnitManagement.Utilities;
 using ScaleUnitManagement.WorkloadSetupOrchestrator;
@@ -13,34 +14,12 @@ namespace CLI
         {
             var options = new List<CLIOption>()
             {
-                Option("Drain all workload data pipelines", DrainAllPipelines),
-                Option("Start all workload data pipelines", StartAllPipelines),
+                Option("Drain workload data pipelines", new DrainPipelines().Show),
+                Option("Start workload data pipelines", new StartPipelines().Show),
             };
 
             var screen = new SingleSelectScreen(options, selectionHistory, "Please select the operation you would like to perform:\n", "\nOperation to perform: ");
             await CLIController.ShowScreen(screen);
-        }
-
-        public async Task DrainAllPipelines(int input, string selectionHistory)
-        {
-            foreach (ScaleUnitInstance scaleUnit in GetSortedScaleUnits())
-            {
-                using var context = ScaleUnitContext.CreateContext(scaleUnit.ScaleUnitId);
-                var pipelineManager = new PipelineManager();
-                await pipelineManager.DrainWorkloadDataPipelines();
-            }
-            Console.WriteLine("Done.");
-        }
-
-        public async Task StartAllPipelines(int input, string selectionHistory)
-        {
-            foreach (ScaleUnitInstance scaleUnit in GetSortedScaleUnits())
-            {
-                using var context = ScaleUnitContext.CreateContext(scaleUnit.ScaleUnitId);
-                var pipelineManager = new PipelineManager();
-                await pipelineManager.StartWorkloadDataPipelines();
-            }
-            Console.WriteLine("Done.");
         }
     }
 }

--- a/src/CLI/RootMenu.cs
+++ b/src/CLI/RootMenu.cs
@@ -14,7 +14,7 @@ namespace CLI
                 Option("Prepare environments for workload installation", new ConfigureEnvironment().Show),
                 Option("Show workload installation options", new WorkloadInstallationMenu().Show),
                 Option("Show workload movement options", new WorkloadMovementMenu().Show),
-                Option("Upgrade workloads definition", new UpgradeWorkloadsDefinition().UpgradeAllWorkloadDefinitions),
+                Option("Upgrade workloads definition", new UpgradeWorkloadsDefinition().Show),
                 Option("Show workload data pipeline management options", new ManageWorkloadDataPipeline().Show),
                 Option("Delete workloads from environment", new DeleteWorkloads().Show),
                 Option("Setup tools", new SetupTools().Show),

--- a/src/CLI/UpgradeWorkloadsDefinition.cs
+++ b/src/CLI/UpgradeWorkloadsDefinition.cs
@@ -1,27 +1,26 @@
-using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using CLIFramework;
-using ScaleUnitManagement.Utilities;
 using ScaleUnitManagement.WorkloadSetupOrchestrator;
 
 namespace CLI
 {
-    internal class UpgradeWorkloadsDefinition
+    internal class UpgradeWorkloadsDefinition : DevToolMenu
     {
-        public async Task UpgradeAllWorkloadDefinitions(int input, string selectionHistory)
+        public override async Task Show(int input, string selectionHistory)
         {
-            if (!CLIController.YesNoPrompt("You are about to upgrade the workload definitions on all scale units. Do you wish to continue? [y]: "))
-                return;
+            List<CLIOption> options = SelectScaleUnitOptions(GetSortedScaleUnits(), Upgrade);
+            var screen = new MultiSelectScreen(options, selectionHistory,
+                $"Please select the environment(s) you want to upgrade the workload definitions on\n" +
+                $"Press enter to upgrade the workloads on all environments.\n",
+                "\nWhich environment would you like to upgrade the workloads on?: ");
+            await CLIController.ShowScreen(screen);
+        }
 
-            List<ScaleUnitInstance> scaleUnits = Config.ScaleUnitInstances();
-            foreach (ScaleUnitInstance scaleUnit in scaleUnits)
-            {
-                using var context = ScaleUnitContext.CreateContext(scaleUnit.ScaleUnitId);
-                var workloadDefinitionManager = new WorkloadDefinitionManager();
-                await workloadDefinitionManager.UpgradeWorkloadsDefinition();
-            }
-            Console.WriteLine("Done");
+        public async Task Upgrade(int input, string selectionHistory)
+        {
+            var workloadDefinitionManager = new WorkloadDefinitionManager();
+            await workloadDefinitionManager.UpgradeWorkloadsDefinition();
         }
     }
 }

--- a/src/CLI/UpgradeWorkloadsDefinition.cs
+++ b/src/CLI/UpgradeWorkloadsDefinition.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using CLIFramework;
@@ -15,6 +16,8 @@ namespace CLI
                 $"Press enter to upgrade the workloads on all environments.\n",
                 "\nWhich environment would you like to upgrade the workloads on?: ");
             await CLIController.ShowScreen(screen);
+
+            Console.WriteLine("Done\n");
         }
 
         public async Task Upgrade(int input, string selectionHistory)

--- a/src/CLI/WorkloadDataPipelineOptions/DrainPipelines.cs
+++ b/src/CLI/WorkloadDataPipelineOptions/DrainPipelines.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using CLIFramework;
+using ScaleUnitManagement.WorkloadSetupOrchestrator;
+
+namespace CLI.WorkloadDataPipelineOptions
+{
+    internal class DrainPipelines : DevToolMenu
+    {
+        public override async Task Show(int input, string selectionHistory)
+        {
+            List<CLIOption> options = SelectScaleUnitOptions(GetSortedScaleUnits(), Drain);
+            var screen = new MultiSelectScreen(options, selectionHistory,
+                $"Please select the environment(s) you want to drain\n" +
+                $"Press enter to drain the workloads on all environments.\n",
+                "\nWhich environment would you like to drain?: ");
+            await CLIController.ShowScreen(screen);
+
+            Console.WriteLine("Done\n");
+        }
+
+        public async Task Drain(int input, string selectionHistory)
+        {
+            var pipelineManager = new PipelineManager();
+            await pipelineManager.DrainWorkloadDataPipelines();
+        }
+    }
+}

--- a/src/CLI/WorkloadDataPipelineOptions/StartPipelines.cs
+++ b/src/CLI/WorkloadDataPipelineOptions/StartPipelines.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using CLIFramework;
+using ScaleUnitManagement.WorkloadSetupOrchestrator;
+
+namespace CLI.WorkloadDataPipelineOptions
+{
+    internal class StartPipelines : DevToolMenu
+    {
+        public override async Task Show(int input, string selectionHistory)
+        {
+            List<CLIOption> options = SelectScaleUnitOptions(GetSortedScaleUnits(), Start);
+            var screen = new MultiSelectScreen(options, selectionHistory,
+                $"Please select the environment(s) you want to start.\n" +
+                $"Press enter to start the workloads on all environments.\n",
+                "\nWhich environment would you like to start?: ");
+            await CLIController.ShowScreen(screen);
+
+            Console.WriteLine("Done\n");
+        }
+
+        public async Task Start(int input, string selectionHistory)
+        {
+            var pipelineManager = new PipelineManager();
+            await pipelineManager.StartWorkloadDataPipelines();
+        }
+    }
+}

--- a/src/ScaleUnitManagement/WorkloadSetupOrchestrator/WorkloadDefinitionManager.cs
+++ b/src/ScaleUnitManagement/WorkloadSetupOrchestrator/WorkloadDefinitionManager.cs
@@ -34,6 +34,8 @@ namespace ScaleUnitManagement.WorkloadSetupOrchestrator
                 workloadInstance.VersionedWorkload.Workload = workload;
                 workloadInstance.VersionedWorkload.Id = Guid.NewGuid().ToString();
 
+                Console.WriteLine($"Upgrading the definition of {workloadName} workload on {scaleUnit.PrintableName()}");
+
                 await ReliableRun.Execute(async () => await scaleUnitAosClient.WriteWorkloadInstances(new List<WorkloadInstance> { workloadInstance }), "Writing workload instance");
             }
         }


### PR DESCRIPTION
By using the MultiSelectMenu the user can choose a specific environment to perform the action on. This is useful if for example the drain succeeded on hub but not on spoke. Before, retrying would produce an error because the hub was already drained, but now drain can be retried only on the spoke. It is still easy to select all environments just by pressing enter in the menu.

Also, upgrade workloads now prints its progress to the user.