### PR TITLE
Turn null from AOS into empty lists #patch

### DIFF
--- a/src/ScaleUnitManagement/WorkloadSetupOrchestrator/Utilities/AOSClient.cs
+++ b/src/ScaleUnitManagement/WorkloadSetupOrchestrator/Utilities/AOSClient.cs
@@ -81,7 +81,7 @@ namespace ScaleUnitManagement.WorkloadSetupOrchestrator.Utilities
             string result = await SendRequest(path, writePayload);
             string json = JsonConvert.DeserializeObject<string>(result);
             List<WorkloadInstance> parsed = JsonConvert.DeserializeObject<List<WorkloadInstance>>(json);
-            return parsed;
+            return parsed ?? new List<WorkloadInstance>();
         }
 
         public async Task<List<WorkloadInstance>> DeleteWorkloadInstances(List<WorkloadInstance> workloadInstances)
@@ -99,7 +99,7 @@ namespace ScaleUnitManagement.WorkloadSetupOrchestrator.Utilities
 
             string json = JsonConvert.DeserializeObject<string>(result);
             List<WorkloadInstance> parsed = JsonConvert.DeserializeObject<List<WorkloadInstance>>(json);
-            return parsed;
+            return parsed ?? new List<WorkloadInstance>();
         }
 
         public async Task<List<Workload>> GetWorkloads()
@@ -114,7 +114,7 @@ namespace ScaleUnitManagement.WorkloadSetupOrchestrator.Utilities
 
             string json = JsonConvert.DeserializeObject<string>(result);
             List<Workload> parsed = JsonConvert.DeserializeObject<List<Workload>>(json);
-            return parsed;
+            return parsed ?? new List<Workload>();
         }
 
         public async Task<List<WorkloadInstance>> GetWorkloadInstances()
@@ -129,7 +129,7 @@ namespace ScaleUnitManagement.WorkloadSetupOrchestrator.Utilities
 
             string json = JsonConvert.DeserializeObject<string>(result);
             List<WorkloadInstance> parsed = JsonConvert.DeserializeObject<List<WorkloadInstance>>(json);
-            return parsed;
+            return parsed ?? new List<WorkloadInstance>();
         }
 
         public async Task<WorkloadInstanceStatus> CheckWorkloadStatus(string workloadInstanceId)


### PR DESCRIPTION
If there are no workloads or workload instances on the server, then the response from AOS will be null. This is now interpreted as an empty list.
Tested with single command execution.
Resolves #122 