### PR TITLE
Ping AOS whenever an AOSClient is constructed

### DIFF
--- a/src/ScaleUnitManagement/WorkloadSetupOrchestrator/AOSCommunicator.cs
+++ b/src/ScaleUnitManagement/WorkloadSetupOrchestrator/AOSCommunicator.cs
@@ -20,7 +20,7 @@ namespace ScaleUnitManagement.WorkloadSetupOrchestrator
             if (scaleUnitAosClient is null)
             {
                 ScaleUnitInstance scaleUnit = Config.FindScaleUnitWithId(ScaleUnitContext.GetScaleUnitId());
-                SetScaleUnitAosClient(await AOSClient.Construct(scaleUnit));
+                await ReliableRun.Execute(async () => SetScaleUnitAosClient(await AOSClient.Construct(scaleUnit)), "Connecting to AOS");
             }
             return scaleUnitAosClient;
         }
@@ -30,7 +30,7 @@ namespace ScaleUnitManagement.WorkloadSetupOrchestrator
             if (hubAosClient is null)
             {
                 ScaleUnitInstance hub = Config.HubScaleUnit();
-                SetHubAosClient(await AOSClient.Construct(hub));
+                await ReliableRun.Execute(async () => SetHubAosClient(await AOSClient.Construct(hub)), "Connecting to AOS");
             }
             return hubAosClient;
         }

--- a/src/ScaleUnitManagement/WorkloadSetupOrchestrator/Utilities/AOSClient.cs
+++ b/src/ScaleUnitManagement/WorkloadSetupOrchestrator/Utilities/AOSClient.cs
@@ -202,7 +202,7 @@ namespace ScaleUnitManagement.WorkloadSetupOrchestrator.Utilities
             }
             catch (TaskCanceledException)
             {
-                throw new TaskCanceledException("The server did not respond before timeout");
+                throw new Exception("The server did not respond before timeout");
             }
 
             string result = await response.Content.ReadAsStringAsync();

--- a/src/ScaleUnitManagement/WorkloadSetupOrchestrator/Utilities/ReliableRun.cs
+++ b/src/ScaleUnitManagement/WorkloadSetupOrchestrator/Utilities/ReliableRun.cs
@@ -59,11 +59,7 @@ namespace ScaleUnitManagement.WorkloadSetupOrchestrator.Utilities
 
         private static bool IsRetryableAOSCall(Exception exception)
         {
-            if (exception is TaskCanceledException)
-            {
-                return true;
-            }
-            else if (!(exception is AOSClientError))
+            if (!(exception is AOSClientError))
             {
                 return false;
             }

--- a/src/ScaleUnitManagement/WorkloadSetupOrchestrator/Utilities/ReliableRun.cs
+++ b/src/ScaleUnitManagement/WorkloadSetupOrchestrator/Utilities/ReliableRun.cs
@@ -59,7 +59,11 @@ namespace ScaleUnitManagement.WorkloadSetupOrchestrator.Utilities
 
         private static bool IsRetryableAOSCall(Exception exception)
         {
-            if (!(exception is AOSClientError))
+            if (exception is TaskCanceledException)
+            {
+                return true;
+            }
+            else if (!(exception is AOSClientError))
             {
                 return false;
             }


### PR DESCRIPTION
Make sure that the AOS is warm whenever a new client is created.  Improve readability of errors caused by timeout.
#patch
resolves #106
![image](https://user-images.githubusercontent.com/43210147/143026865-081aec39-add9-4d9e-a847-ff3e893be415.png)