### PR TITLE
Install workload in scale unit even if found Ready

### DIFF
--- a/src/ScaleUnitManagement/WorkloadSetupOrchestrator/ScaleUnitWorkloadInstaller.cs
+++ b/src/ScaleUnitManagement/WorkloadSetupOrchestrator/ScaleUnitWorkloadInstaller.cs
@@ -51,9 +51,6 @@ namespace ScaleUnitManagement.WorkloadSetupOrchestrator
 
             foreach (WorkloadInstance workloadInstance in workloadInstances)
             {
-                if (await WorkloadInstanceManager.IsWorkloadInstanceInReadyState(scaleUnitAosClient, workloadInstance))
-                    continue;
-
                 if (!await WorkloadInstanceManager.IsWorkloadInstanceInInstallingState(scaleUnitAosClient, workloadInstance))
                 {
                     Console.WriteLine($"Installing the {workloadInstance.VersionedWorkload.Workload.Name} workload");


### PR DESCRIPTION
We want to install workloads when they are in Ready state in Scale unit, otherwise upgrades and movement to spoke can cause problems. Since there is no _real_ workload versioning in the dev tools, we need to just overwrite on every install as we can't know what has changed without introspecting the hub workload versus what is installed in the scale unit.

#patch

Fixes #126.