### PR TITLE
Turn auto-close off during initialization #patch

### DIFF
--- a/src/ScaleUnitManagement/ScaleUnitFeatureManager/ScaleUnit/DisableDbAutoClose.cs
+++ b/src/ScaleUnitManagement/ScaleUnitFeatureManager/ScaleUnit/DisableDbAutoClose.cs
@@ -4,11 +4,11 @@ using ScaleUnitManagement.Utilities;
 
 namespace ScaleUnitManagement.ScaleUnitFeatureManager.ScaleUnit
 {
-    public class SetAutoClose : IScaleUnitStep
+    public class DisableDbAutoClose : IScaleUnitStep
     {
         public string Label()
         {
-            return "Set DB auto-close to false";
+            return "Disable DB auto-close";
         }
 
         public float Priority()

--- a/src/ScaleUnitManagement/ScaleUnitFeatureManager/ScaleUnit/SetAutoClose.cs
+++ b/src/ScaleUnitManagement/ScaleUnitFeatureManager/ScaleUnit/SetAutoClose.cs
@@ -1,0 +1,30 @@
+using System.Threading.Tasks;
+using ScaleUnitManagement.ScaleUnitFeatureManager.Utilities;
+using ScaleUnitManagement.Utilities;
+
+namespace ScaleUnitManagement.ScaleUnitFeatureManager.ScaleUnit
+{
+    public class SetAutoClose : IScaleUnitStep
+    {
+        public string Label()
+        {
+            return "Set DB auto-close to false";
+        }
+
+        public float Priority()
+        {
+            return 3.5F;
+        }
+
+        public Task Run()
+        {
+            string axDbName = Config.FindScaleUnitWithId(ScaleUnitContext.GetScaleUnitId()).AxDbName;
+            string query = $"ALTER DATABASE {axDbName} SET AUTO_CLOSE OFF";
+
+            var sqlQueryExecutor = new SqlQueryExecutor();
+            sqlQueryExecutor.Execute(query);
+
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
If auto-close is enabled on the spoke, it will not be able to operate properly. By turning it off during initialization this is avoided.

Tested on one-box environment. Verified that the auto-close property is turned off during initialization of the spoke.

closes #129