### PR TITLE
Print more details during workload movement #patch

### DIFF
--- a/src/CLI/SetupTools.cs
+++ b/src/CLI/SetupTools.cs
@@ -16,7 +16,6 @@ namespace CLI
                 Option("Update scale unit id", new UpdateScaleUnitId().Show),
                 Option("Clean up Azure storage account for a scale unit", new CleanUpStorageAccount().Show),
                 Option("Import workloads from Azure storage blob with SAS url", new ImportWorkloadBlob().Show),
-                Option("Perform emergency transition from scale unit to hub", new PerformEmergencyTransitionToHub().Show)
             };
 
             var screen = new SingleSelectScreen(options, selectionHistory, "Please select the operation you want to perform:\n", "\nOperation to perform: ");

--- a/src/CLI/WorkloadMovementMenu.cs
+++ b/src/CLI/WorkloadMovementMenu.cs
@@ -13,6 +13,7 @@ namespace CLI
             {
                 Option("Move all workloads to the hub", new MoveWorkloads().MoveAllWorkloads),
                 Option("Show workload movement status", new WorkloadMovementStatus().Show),
+                Option("Perform emergency transition from scale unit to hub", new PerformEmergencyTransitionToHub().Show)
             };
 
             var screen = new SingleSelectScreen(options, selectionHistory, "Please select the operation you would like to perform:\n", "\nOperation to perform: ");

--- a/src/CLI/WorkloadMovementOptions/MoveWorkloads.cs
+++ b/src/CLI/WorkloadMovementOptions/MoveWorkloads.cs
@@ -29,9 +29,8 @@ namespace CLI.WorkloadMovementOptions
         private async Task MoveWorkloadsFromScaleUnitToHub(ScaleUnitInstance scaleUnit)
         {
             using var context = ScaleUnitContext.CreateContext(scaleUnit.ScaleUnitId);
-            string hubId = "@@";
             var workloadMover = new WorkloadMover();
-            await workloadMover.MoveWorkloads(hubId);
+            await workloadMover.MoveWorkloadsToHub();
         }
     }
 }

--- a/src/CLI/WorkloadMovementOptions/PerformEmergencyTransitionToHub.cs
+++ b/src/CLI/WorkloadMovementOptions/PerformEmergencyTransitionToHub.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using ScaleUnitManagement.Utilities;
 using ScaleUnitManagement.WorkloadSetupOrchestrator;
 
-namespace CLI.SetupToolsOptions
+namespace CLI
 {
     internal class PerformEmergencyTransitionToHub : DevToolMenu
     {

--- a/src/ScaleUnitManagement/WorkloadSetupOrchestrator/WorkloadMover.cs
+++ b/src/ScaleUnitManagement/WorkloadSetupOrchestrator/WorkloadMover.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using CloudAndEdgeLibs.Contracts;
 using ScaleUnitManagement.WorkloadSetupOrchestrator.Utilities;
+using ScaleUnitManagement.Utilities;
 
 namespace ScaleUnitManagement.WorkloadSetupOrchestrator
 {
@@ -11,9 +12,10 @@ namespace ScaleUnitManagement.WorkloadSetupOrchestrator
     {
         public WorkloadMover() : base() { }
 
-        public async Task MoveWorkloads(string moveToId)
+        public async Task MoveWorkloadsToHub()
         {
             IAOSClient aosClient = await GetScaleUnitAosClient();
+            string hubId = Config.HubScaleUnit().ScaleUnitId;
             DateTime movementDateTime = DateTime.UtcNow.AddMinutes(5);
             List<WorkloadInstance> workloadInstances = null;
             await ReliableRun.Execute(async () => workloadInstances = await aosClient.GetWorkloadInstances(), "Getting workload instances");
@@ -29,12 +31,12 @@ namespace ScaleUnitManagement.WorkloadSetupOrchestrator
                 if (workloadInstance.ExecutingEnvironment.Any())
                 {
                     TemporalAssignment lastAssignment = workloadInstance.ExecutingEnvironment.Last();
-                    if (moveToId.Equals(lastAssignment?.Environment.ScaleUnitId))
+                    if (hubId.Equals(lastAssignment?.Environment.ScaleUnitId))
                     {
                         continue;
                     }
                 }
-                workloadInstance.ExecutingEnvironment.Add(CreateTemporalAssignment(moveToId, movementDateTime));
+                workloadInstance.ExecutingEnvironment.Add(CreateTemporalAssignment(hubId, movementDateTime));
 
                 await ReliableRun.Execute(async () => await aosClient.WriteWorkloadInstances(new List<WorkloadInstance> { workloadInstance }), $"Moving workload instance from scale unit {scaleUnit.ScaleUnitId} to the hub");
                 Console.WriteLine($"Registered movement to hub for {workloadInstance.VersionedWorkload.Workload.Name} workload with id {workloadInstance.Id} on scale unit {scaleUnit.ScaleUnitId}");

--- a/src/ScaleUnitManagement/WorkloadSetupOrchestrator/WorkloadMover.cs
+++ b/src/ScaleUnitManagement/WorkloadSetupOrchestrator/WorkloadMover.cs
@@ -37,13 +37,13 @@ namespace ScaleUnitManagement.WorkloadSetupOrchestrator
                 workloadInstance.ExecutingEnvironment.Add(CreateTemporalAssignment(moveToId, movementDateTime));
 
                 await ReliableRun.Execute(async () => await aosClient.WriteWorkloadInstances(new List<WorkloadInstance> { workloadInstance }), $"Moving workload instance from scale unit {scaleUnit.ScaleUnitId} to the hub");
-                Console.WriteLine($"Initiated movement to hub for {workloadInstance.VersionedWorkload.Workload.Name} workload on scale unit {scaleUnit.ScaleUnitId}");
+                Console.WriteLine($"Registered movement to hub for {workloadInstance.VersionedWorkload.Workload.Name} workload with id {workloadInstance.Id} on scale unit {scaleUnit.ScaleUnitId}");
                 movedWorkloads++;
             }
 
             if (movedWorkloads == 0)
             {
-                Console.WriteLine($"All workloads on scale unit {scaleUnit.ScaleUnitId} where already assigned to the hub.");
+                Console.WriteLine($"All workloads on scale unit {scaleUnit.ScaleUnitId} where already assigned to the hub. See movement status to check the progress.");
             }
         }
 

--- a/src/ScaleUnitManagement/WorkloadSetupOrchestrator/WorkloadMover.cs
+++ b/src/ScaleUnitManagement/WorkloadSetupOrchestrator/WorkloadMover.cs
@@ -18,6 +18,12 @@ namespace ScaleUnitManagement.WorkloadSetupOrchestrator
             List<WorkloadInstance> workloadInstances = null;
             await ReliableRun.Execute(async () => workloadInstances = await aosClient.GetWorkloadInstances(), "Getting workload instances");
 
+            if (workloadInstances.Count == 0)
+            {
+                Console.WriteLine($"There are no workloads to move on scale unit {scaleUnit.ScaleUnitId}.");
+            }
+            int movedWorkloads = 0;
+
             foreach (WorkloadInstance workloadInstance in workloadInstances)
             {
                 if (workloadInstance.ExecutingEnvironment.Any())
@@ -31,6 +37,13 @@ namespace ScaleUnitManagement.WorkloadSetupOrchestrator
                 workloadInstance.ExecutingEnvironment.Add(CreateTemporalAssignment(moveToId, movementDateTime));
 
                 await ReliableRun.Execute(async () => await aosClient.WriteWorkloadInstances(new List<WorkloadInstance> { workloadInstance }), $"Moving workload instance from scale unit {scaleUnit.ScaleUnitId} to the hub");
+                Console.WriteLine($"Initiated movement to hub for {workloadInstance.VersionedWorkload.Workload.Name} workload on scale unit {scaleUnit.ScaleUnitId}");
+                movedWorkloads++;
+            }
+
+            if (movedWorkloads == 0)
+            {
+                Console.WriteLine($"All workloads on scale unit {scaleUnit.ScaleUnitId} where already assigned to the hub.");
             }
         }
 

--- a/src/ScaleUnitManagementTests/MoveWorkloadsTest.cs
+++ b/src/ScaleUnitManagementTests/MoveWorkloadsTest.cs
@@ -30,7 +30,7 @@ namespace ScaleUnitManagementTests
             {
                 WorkloadMover workloadMover = new WorkloadMover();
                 workloadMover.SetScaleUnitAosClient(aosClient.Object);
-                await workloadMover.MoveWorkloads(hubId);
+                await workloadMover.MoveWorkloadsToHub();
             }
 
             // Assert


### PR DESCRIPTION
Print the name of every workload moved when initiating movements. Also inform the user if no workloads are moved, referring the user to see movement status.

closes #125 