### PR TITLE
Enable multibox deployment script

### DIFF
--- a/src/CLI/Program.cs
+++ b/src/CLI/Program.cs
@@ -26,32 +26,14 @@ namespace CLI
             }
             catch (Exception ex)
             {
-                Console.WriteLine(ex);
+                Console.WriteLine(ex.Message);
                 Console.WriteLine("\n" + argumentParser.HelpMessage());
                 return;
             }
 
-            var deployer = new Deployer();
+            var argumentHandler = new ArgumentHandler();
+            await argumentHandler.RunScripts(argumentParser);
 
-            if (argumentParser.CleanStorage)
-            {
-                await deployer.CleanStorage();
-            }
-
-            if (argumentParser.Deploy)
-            {
-                await deployer.Deploy();
-            }
-
-            if (argumentParser.DrainPipelines)
-            {
-                await deployer.DrainAllPipelines();
-            }
-
-            if (argumentParser.StartPipelines)
-            {
-                await deployer.StartAllPipelines();
-            }
         }
     }
 }

--- a/src/CLI/Program.cs
+++ b/src/CLI/Program.cs
@@ -26,7 +26,7 @@ namespace CLI
             }
             catch (Exception ex)
             {
-                Console.WriteLine(ex.Message);
+                Console.WriteLine(ex);
                 Console.WriteLine("\n" + argumentParser.HelpMessage());
                 return;
             }

--- a/src/CLI/Utilities/ArgumentHandler.cs
+++ b/src/CLI/Utilities/ArgumentHandler.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using CLI.Actions;
+using ScaleUnitManagement.Utilities;
+
+namespace CLI.Utilities
+{
+    internal class ArgumentHandler
+    {
+        internal async Task RunScripts(ArgumentParser argumentParser)
+        {
+            List<ScaleUnitInstance> sortedScaleUnitInstances = Config.ScaleUnitInstances();
+            sortedScaleUnitInstances.Sort();
+
+            if (argumentParser.CleanStorage)
+            {
+                foreach (ScaleUnitInstance scaleUnit in sortedScaleUnitInstances)
+                {
+                    Console.WriteLine($"\nCleaning environment on {scaleUnit.PrintableName()}");
+                    var action = new CleanUpStorageAccountAction(scaleUnit.ScaleUnitId);
+                    await action.Execute();
+                }
+            }
+
+            if (argumentParser.SingleBoxDeploy)
+            {
+                var deployer = new SingleBoxDeployer();
+                await deployer.Deploy();
+            }
+
+            if (argumentParser.HubDeploy)
+            {
+                var deployer = new ScaleUnitDeployer(Config.HubScaleUnit());
+                await deployer.Deploy();
+            }
+
+            if (argumentParser.SpokeDeploy)
+            {
+                ScaleUnitInstance spoke = Config.NonHubScaleUnitInstances().First();
+                var deployer = new ScaleUnitDeployer(spoke);
+                await deployer.Deploy();
+            }
+
+            if (argumentParser.DrainPipelines)
+            {
+                Console.WriteLine($"\nDraining all data pipelines");
+                foreach (ScaleUnitInstance scaleUnit in sortedScaleUnitInstances)
+                {
+                    var action = new DrainPipelinesAction(scaleUnit.ScaleUnitId);
+                    await action.Execute();
+                }
+                Console.WriteLine("Done.");
+            }
+
+            if (argumentParser.StartPipelines)
+            {
+                Console.WriteLine($"\nStarting all data pipelines");
+                foreach (ScaleUnitInstance scaleUnit in sortedScaleUnitInstances)
+                {
+                    var action = new StartPipelinesAction(scaleUnit.ScaleUnitId);
+                    await action.Execute();
+                }
+                Console.WriteLine("Done.");
+            }
+        }
+    }
+}

--- a/src/CLI/Utilities/ArgumentParser.cs
+++ b/src/CLI/Utilities/ArgumentParser.cs
@@ -4,7 +4,9 @@ namespace CLI.Utilities
 {
     public class ArgumentParser
     {
-        public bool Deploy { get; set; } = false;
+        public bool SingleBoxDeploy { get; set; } = false;
+        public bool HubDeploy { get; set; } = false;
+        public bool SpokeDeploy { get; set; } = false;
         public bool CleanStorage { get; set; } = false;
         public bool DrainPipelines { get; set; } = false;
         public bool StartPipelines { get; set; } = false;
@@ -17,7 +19,9 @@ namespace CLI.Utilities
             arguments = args;
             matched = new bool[args.Length];
 
-            Deploy = ParseArgument("--single-box-deploy");
+            SingleBoxDeploy = ParseArgument("--single-box-deploy");
+            HubDeploy = ParseArgument("--hub-deploy");
+            SpokeDeploy = ParseArgument("--spoke-deploy");
             CleanStorage = ParseArgument("--clean-storage");
             DrainPipelines = ParseArgument("--drain-pipelines");
             StartPipelines = ParseArgument("--start-pipelines");
@@ -29,6 +33,8 @@ namespace CLI.Utilities
                     throw new Exception($"Did not recognize argument {args[i]}.");
                 }
             }
+
+            Validate();
         }
 
         private bool ParseArgument(string argument)
@@ -42,11 +48,21 @@ namespace CLI.Utilities
             return false;
         }
 
+        private void Validate()
+        {
+            if ((SingleBoxDeploy && HubDeploy) || (SingleBoxDeploy && SpokeDeploy) || (HubDeploy && SpokeDeploy))
+            {
+                throw new Exception("You can only use one deploy option at a time.");
+            }
+        }
+
         public string HelpMessage()
         {
             return "Usage: program [options]\n" +
-                "--clean-storage        Cleans all Azure storage accounts for hub and spoke\n" +
                 "--single-box-deploy    Prepares and installs hub and spoke environments\n" +
+                "--hub-deploy           Prepares and installs the hub\n" +
+                "--spoke-deploy         Prepares and installs the spoke. Only use this after the hub has been successfully deployed\n" +
+                "--clean-storage        Cleans all Azure storage accounts for hub and spoke\n" +
                 "--drain-pipelines      Drains pipelines between hub and spoke\n" +
                 "--start-pipelines      Starts pipelines between hub and spoke\n" +
                 "If no options are given the UI will run.";

--- a/src/CLI/Utilities/Deployer.cs
+++ b/src/CLI/Utilities/Deployer.cs
@@ -7,99 +7,36 @@ using ScaleUnitManagement.Utilities;
 
 namespace CLI.Utilities
 {
-    internal class Deployer
+    internal abstract class Deployer
     {
-        private readonly List<ScaleUnitInstance> sortedScaleUnitInstances;
+        public abstract Task Deploy();
 
-        public Deployer()
+        protected async Task InitializeEnvironments(ScaleUnitInstance scaleUnit)
         {
-            sortedScaleUnitInstances = Config.ScaleUnitInstances();
-            sortedScaleUnitInstances.Sort();
-        }
-
-        public async Task Deploy()
-        {
-            if (!Config.UseSingleOneBox())
+            Console.WriteLine($"\nInitializing environment on {scaleUnit.PrintableName()}");
+            var stepGenerator = new StepGenerator(scaleUnit.ScaleUnitId);
+            List<IStep> steps = stepGenerator.GetSteps();
+            foreach (IStep step in steps)
             {
-                throw new Exception("You can only use automatic deployment in a SingleOneBox environment");
-            }
-
-            await InitializeEnvironments();
-            await ConfigureEnvironments();
-            await InstallWorkloads();
-
-            Console.WriteLine("\nHub and spoke environments have been deployed successfully!\n");
-        }
-
-        public async Task CleanStorage()
-        {
-            foreach (ScaleUnitInstance scaleUnit in sortedScaleUnitInstances)
-            {
-                Console.WriteLine($"\nCleaning environment on {scaleUnit.PrintableName()}");
-                var action = new CleanUpStorageAccountAction(scaleUnit.ScaleUnitId);
+                var action = new StepAction(scaleUnit.ScaleUnitId, step);
                 await action.Execute();
             }
+
+            Console.WriteLine($"\nAll initialization steps completed for {scaleUnit.PrintableName()}");
         }
 
-        public async Task DrainAllPipelines()
+        protected async Task ConfigureEnvironments(ScaleUnitInstance scaleUnit)
         {
-            Console.WriteLine($"\nDraining all data pipelines");
-            foreach (ScaleUnitInstance scaleUnit in Config.ScaleUnitInstances())
-            {
-                var action = new DrainPipelinesAction(scaleUnit.ScaleUnitId);
-                await action.Execute();
-            }
-            Console.WriteLine("Done.");
+            Console.WriteLine($"\nPreparing {scaleUnit.PrintableName()} for installation");
+            var action = new ConfigureEnvironmentAction(scaleUnit.ScaleUnitId);
+            await action.Execute();
         }
 
-        public async Task StartAllPipelines()
+        protected async Task InstallWorkloads(ScaleUnitInstance scaleUnit)
         {
-            Console.WriteLine($"\nStarting all data pipelines");
-            foreach (ScaleUnitInstance scaleUnit in Config.ScaleUnitInstances())
-            {
-                var action = new StartPipelinesAction(scaleUnit.ScaleUnitId);
-                await action.Execute();
-            }
-            Console.WriteLine("Done.");
-        }
-
-        private async Task InitializeEnvironments()
-        {
-            foreach (ScaleUnitInstance scaleUnit in sortedScaleUnitInstances)
-            {
-                Console.WriteLine($"\nInitializing environment on {scaleUnit.PrintableName()}");
-                var stepGenerator = new StepGenerator(scaleUnit.ScaleUnitId);
-                List<IStep> steps = stepGenerator.GetSteps();
-                foreach (IStep step in steps)
-                {
-                    var action = new StepAction(scaleUnit.ScaleUnitId, step);
-                    await action.Execute();
-                }
-
-                Console.WriteLine($"\nAll initialization steps completed for {scaleUnit.PrintableName()}");
-            }
-        }
-
-        private async Task ConfigureEnvironments()
-        {
-            foreach (ScaleUnitInstance scaleUnit in sortedScaleUnitInstances)
-            {
-                Console.WriteLine($"\nPreparing {scaleUnit.PrintableName()} for installation");
-                var action = new ConfigureEnvironmentAction(scaleUnit.ScaleUnitId);
-                await action.Execute();
-            }
-        }
-
-        private async Task InstallWorkloads()
-        {
-            foreach (ScaleUnitInstance scaleUnit in sortedScaleUnitInstances)
-            {
-                Console.WriteLine($"\nInstalling workloads on {scaleUnit.PrintableName()}");
-                var action = new InstallWorkloadsAction(scaleUnit.ScaleUnitId);
-                await action.Execute();
-            }
+            Console.WriteLine($"\nInstalling workloads on {scaleUnit.PrintableName()}");
+            var action = new InstallWorkloadsAction(scaleUnit.ScaleUnitId);
+            await action.Execute();
         }
     }
 }
-
-

--- a/src/CLI/Utilities/ScaleUnitDeployer.cs
+++ b/src/CLI/Utilities/ScaleUnitDeployer.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Threading.Tasks;
+using ScaleUnitManagement.Utilities;
+
+namespace CLI.Utilities
+{
+    internal class ScaleUnitDeployer : Deployer
+    {
+        private readonly ScaleUnitInstance scaleUnit;
+
+        public ScaleUnitDeployer(ScaleUnitInstance scaleUnit) : base()
+        {
+            this.scaleUnit = scaleUnit;
+        }
+
+        public override async Task Deploy()
+        {
+            Console.WriteLine($"Deploying scale unit {scaleUnit.PrintableName()}");
+
+            await InitializeEnvironments(scaleUnit);
+            await ConfigureEnvironments(scaleUnit);
+            await InstallWorkloads(scaleUnit);
+
+            Console.WriteLine($"\nScale unit {scaleUnit.PrintableName()} has been deployed successfully!\n");
+        }
+    }
+}

--- a/src/CLI/Utilities/SingleBoxDeployer.cs
+++ b/src/CLI/Utilities/SingleBoxDeployer.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using ScaleUnitManagement.Utilities;
+
+namespace CLI.Utilities
+{
+    internal class SingleBoxDeployer : Deployer
+    {
+        public override async Task Deploy()
+        {
+            List<ScaleUnitInstance> sortedScaleUnitInstances = Config.ScaleUnitInstances();
+            sortedScaleUnitInstances.Sort();
+
+            if (!Config.UseSingleOneBox())
+            {
+                throw new Exception("You can only use automatic deployment in a SingleOneBox environment");
+            }
+
+            foreach (ScaleUnitInstance scaleUnit in sortedScaleUnitInstances)
+            {
+                await InitializeEnvironments(scaleUnit);
+            }
+            foreach (ScaleUnitInstance scaleUnit in sortedScaleUnitInstances)
+            {
+                await ConfigureEnvironments(scaleUnit);
+            }
+            foreach (ScaleUnitInstance scaleUnit in sortedScaleUnitInstances)
+            {
+                await InstallWorkloads(scaleUnit);
+            }
+
+            Console.WriteLine("\nHub and spoke environments have been deployed successfully!\n");
+        }
+    }
+}

--- a/src/ScaleUnitManagementTests/ArgumentParserTest.cs
+++ b/src/ScaleUnitManagementTests/ArgumentParserTest.cs
@@ -20,10 +20,12 @@ namespace ScaleUnitManagementTests
         public void BeforeParsing_HasInitialValues()
         {
             // Arrange + Act + Assert
-            argumentParser.Deploy.Should().BeFalse();
+            argumentParser.SingleBoxDeploy.Should().BeFalse();
             argumentParser.CleanStorage.Should().BeFalse();
             argumentParser.DrainPipelines.Should().BeFalse();
             argumentParser.StartPipelines.Should().BeFalse();
+            argumentParser.HubDeploy.Should().BeFalse();
+            argumentParser.SpokeDeploy.Should().BeFalse();
         }
 
         [TestMethod]
@@ -34,7 +36,7 @@ namespace ScaleUnitManagementTests
             argumentParser.Parse(arguments);
 
             // Assert
-            argumentParser.Deploy.Should().BeTrue();
+            argumentParser.SingleBoxDeploy.Should().BeTrue();
             argumentParser.CleanStorage.Should().BeTrue();
             argumentParser.DrainPipelines.Should().BeTrue();
             argumentParser.StartPipelines.Should().BeTrue();
@@ -45,6 +47,19 @@ namespace ScaleUnitManagementTests
         {
             // Arrange
             string[] arguments = { "--unknown-argument" };
+
+            // Act
+            Action act = () => argumentParser.Parse(arguments);
+
+            // Assert
+            act.Should().Throw<Exception>();
+        }
+
+        [TestMethod]
+        public void Parse_WithMultipleDeployArguments_ThrowsError()
+        {
+            // Arrange
+            string[] arguments = { "--hub-deploy --spoke-deploy" };
 
             // Act
             Action act = () => argumentParser.Parse(arguments);


### PR DESCRIPTION
The user can type --hub-deploy or --spoke-deploy to run deployment for one of the scale units.
The deployer class is made abstract, and is implemented by the SingleBoxDeployer and the ScaleUnitDeployer.