### PR TITLE
Fix bug when entering wrong input

### DIFF
--- a/src/CLIFramework/MultiSelectScreen.cs
+++ b/src/CLIFramework/MultiSelectScreen.cs
@@ -12,6 +12,8 @@ namespace CLIFramework
 
         public override async Task PerformAction(string input)
         {
+            inputValidationError = "";
+
             var allOptions = new List<CLIOption>();
             allOptions.AddRange(options);
             allOptions.AddRange(navigationOptions);

--- a/src/CLIFramework/SingleSelectScreen.cs
+++ b/src/CLIFramework/SingleSelectScreen.cs
@@ -10,6 +10,8 @@ namespace CLIFramework
 
         public override async Task PerformAction(string input)
         {
+            inputValidationError = "";
+
             var allOptions = new List<CLIOption>();
             allOptions.AddRange(options);
             allOptions.AddRange(navigationOptions);

--- a/src/ScaleUnitManagementTests/CLITests/MultiSelectScreenTest.cs
+++ b/src/ScaleUnitManagementTests/CLITests/MultiSelectScreenTest.cs
@@ -143,6 +143,18 @@ namespace ScaleUnitManagementTests.CLITests
         }
 
         [TestMethod]
+        public async Task RunKnownStep_ClearsError()
+        {
+            // Arrange + Act
+            await screen.PerformAction("19");
+            await screen.PerformAction("3");
+
+            // Assert
+            screen.inputValidationError.Should().BeEmpty();
+            executedSteps.Should().BeEquivalentTo(new List<int> { 3 });
+        }
+
+        [TestMethod]
         public async Task EnterNonNumber_ThrowsException()
         {
             // Arrange + Act

--- a/src/ScaleUnitManagementTests/CLITests/SingleSelectScreenTest.cs
+++ b/src/ScaleUnitManagementTests/CLITests/SingleSelectScreenTest.cs
@@ -54,6 +54,18 @@ namespace ScaleUnitManagementTests.CLITests
         }
 
         [TestMethod]
+        public async Task RunKnownStep_ClearsError()
+        {
+            // Arrange + Act
+            await screen.PerformAction("19");
+            await screen.PerformAction("3");
+
+            // Assert
+            screen.inputValidationError.Should().BeEmpty();
+            executedStep.Should().Be(3);
+        }
+
+        [TestMethod]
         public async Task EnterNonNumber_ThrowsException()
         {
             // Arrange + Act


### PR DESCRIPTION
When entering a wrong input in the CLI, like a number outside the range of options, the program would never clear the input error status with subsequent inputs. The program would be stuck in a bad state. Now the error is cleared every time before validating inputs.

Tests included.
Resolves #133 